### PR TITLE
Align checkout progress indicator with site header

### DIFF
--- a/assets/css/checkout.css
+++ b/assets/css/checkout.css
@@ -1,0 +1,544 @@
+:root {
+  --bg: #f7f5f1;
+  --bg-alt: rgba(255, 255, 255, 0.9);
+  --text: #2f2a26;
+  --muted: #8b8177;
+  --accent: #d6a77a;
+  --accent-strong: #c48a55;
+  --line: rgba(150, 140, 130, 0.28);
+  --radius-lg: 24px;
+  --radius-md: 16px;
+  --radius-sm: 10px;
+  --shadow-soft: 0 20px 45px rgba(73, 63, 53, 0.12);
+  --transition: 0.25s ease;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+body {
+  margin: 0;
+  font-family: "Zen Kaku Gothic New", "Hiragino Kaku Gothic ProN", "Yu Gothic", sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
+  letter-spacing: 0.01em;
+}
+
+main {
+  display: block;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus-visible {
+  color: var(--accent-strong);
+}
+
+header {
+  padding: 2.5rem 0 1.5rem;
+}
+
+header .wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: clamp(1rem, 4vw, 2.5rem);
+  flex-wrap: wrap;
+}
+
+.wrapper {
+  width: min(960px, 92vw);
+  margin: 0 auto;
+}
+
+.brand {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.brand__symbol {
+  width: 48px;
+  height: 48px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(214, 167, 122, 0.35), rgba(214, 167, 122, 0.6));
+  display: grid;
+  place-items: center;
+  font-family: "Noto Serif JP", "Yu Mincho", serif;
+  font-weight: 600;
+  color: var(--accent-strong);
+}
+
+.brand__title {
+  font-family: "Noto Serif JP", "Yu Mincho", serif;
+  font-size: clamp(1.35rem, 3vw, 1.8rem);
+  letter-spacing: 0.12em;
+}
+
+.progress {
+  display: flex;
+  gap: 0.75rem;
+  margin: 0 0 0 auto;
+  flex-wrap: wrap;
+  list-style: none;
+  padding: 0;
+}
+
+.progress__step {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.65rem 1.1rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.65);
+  color: var(--muted);
+  border: 1px solid transparent;
+  transition: var(--transition);
+}
+
+.progress__step--current {
+  color: var(--text);
+  background: rgba(214, 167, 122, 0.14);
+  border-color: rgba(214, 167, 122, 0.45);
+  font-weight: 600;
+}
+
+.progress__index {
+  width: 1.65rem;
+  height: 1.65rem;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-size: 0.85rem;
+  font-family: "Noto Serif JP", "Yu Mincho", serif;
+  background: rgba(214, 167, 122, 0.25);
+  color: var(--accent-strong);
+}
+
+h1 {
+  font-family: "Noto Serif JP", "Yu Mincho", serif;
+  font-weight: 500;
+  font-size: clamp(1.8rem, 4vw, 2.4rem);
+  margin: 0 0 0.75rem;
+}
+
+.lead {
+  color: var(--muted);
+  max-width: 580px;
+  font-size: 1rem;
+}
+
+.section {
+  padding: 0 0 3.5rem;
+}
+
+.card {
+  background: var(--bg-alt);
+  border-radius: var(--radius-lg);
+  padding: clamp(1.5rem, 3vw, 2.2rem);
+  box-shadow: var(--shadow-soft);
+  border: 1px solid rgba(255, 255, 255, 0.8);
+}
+
+.card + .card {
+  margin-top: 1.8rem;
+}
+
+.card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  padding: 0.9rem 0.4rem;
+  text-align: left;
+  border-bottom: 1px solid var(--line);
+}
+
+.table td:last-child {
+  text-align: right;
+}
+
+.table th {
+  font-weight: 500;
+  color: var(--muted);
+  font-size: 0.92rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.table td strong {
+  font-weight: 600;
+}
+
+.table .product-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.remove-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  color: var(--muted);
+  font-size: 0.85rem;
+  border: 1px solid transparent;
+  transition: var(--transition);
+}
+
+.remove-link:hover,
+.remove-link:focus-visible {
+  color: var(--accent-strong);
+  border-color: rgba(214, 167, 122, 0.45);
+}
+
+.quantity-control {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  border: 1px solid rgba(214, 167, 122, 0.4);
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.75);
+}
+
+.quantity-control button {
+  appearance: none;
+  border: none;
+  background: transparent;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+  color: var(--accent-strong);
+  transition: var(--transition);
+}
+
+.quantity-control button:hover,
+.quantity-control button:focus-visible {
+  background: rgba(214, 167, 122, 0.14);
+}
+
+.quantity-control input {
+  width: 3rem;
+  text-align: center;
+  border: none;
+  background: transparent;
+  font-size: 0.95rem;
+  padding: 0.4rem 0;
+  color: var(--text);
+}
+
+.quantity-control input:focus {
+  outline: none;
+}
+
+.summary-list {
+  display: grid;
+  gap: 0.75rem;
+  margin: 1.2rem 0 0;
+}
+
+.summary-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  color: var(--muted);
+}
+
+.summary-row--total {
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--line);
+  color: var(--text);
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.coupon-form {
+  display: grid;
+  gap: 0.75rem;
+  margin: 1.8rem 0 0;
+}
+
+.coupon-form label {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.coupon-form .coupon-inputs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+}
+
+.coupon-form button {
+  padding: 0.75rem 1.6rem;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1.9rem;
+  border-radius: 999px;
+  border: none;
+  cursor: pointer;
+  font-family: "Zen Kaku Gothic New", sans-serif;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  transition: var(--transition);
+}
+
+.btn--primary {
+  background: var(--accent);
+  color: #fff;
+}
+
+.btn--primary:hover,
+.btn--primary:focus-visible {
+  background: var(--accent-strong);
+}
+
+.btn--ghost {
+  background: transparent;
+  border: 1px solid var(--line);
+  color: var(--muted);
+}
+
+.btn--ghost:hover,
+.btn--ghost:focus-visible {
+  color: var(--text);
+  border-color: rgba(214, 167, 122, 0.5);
+}
+
+.btn--icon {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  transition: var(--transition);
+}
+
+.btn--icon:hover,
+.btn--icon:focus-visible {
+  color: var(--accent-strong);
+  border-color: rgba(214, 167, 122, 0.35);
+}
+
+.form-grid {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.form-grid--two {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.label {
+  display: block;
+  font-size: 0.85rem;
+  color: var(--muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 0.45rem;
+}
+
+.input {
+  width: 100%;
+  padding: 0.75rem 0.85rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(214, 167, 122, 0.25);
+  background: rgba(255, 255, 255, 0.85);
+  font-size: 0.95rem;
+  transition: var(--transition);
+}
+
+.input:focus {
+  outline: none;
+  border-color: rgba(214, 167, 122, 0.55);
+  box-shadow: 0 0 0 3px rgba(214, 167, 122, 0.18);
+}
+
+.note {
+  font-size: 0.9rem;
+  color: var(--muted);
+  margin-top: 1.2rem;
+}
+
+.payment-methods {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.payment-method {
+  position: relative;
+  border: 1px solid rgba(214, 167, 122, 0.28);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.78);
+  padding: 1rem 1.2rem 1.2rem;
+  box-shadow: 0 15px 30px rgba(73, 63, 53, 0.08);
+}
+
+.payment-method__radio {
+  position: absolute;
+  opacity: 0;
+}
+
+.payment-method__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  cursor: pointer;
+}
+
+.payment-method__title {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  font-weight: 600;
+}
+
+.payment-method__icon {
+  width: 32px;
+  height: 32px;
+  border-radius: 12px;
+  background: rgba(214, 167, 122, 0.18);
+  display: grid;
+  place-items: center;
+  font-size: 1.1rem;
+}
+
+.payment-method__summary {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.payment-method__panel {
+  display: none;
+  margin-top: 1rem;
+  border-top: 1px solid var(--line);
+  padding-top: 1.1rem;
+  gap: 1.2rem;
+}
+
+.payment-method__radio:focus-visible + .payment-method__header {
+  outline: 2px solid rgba(214, 167, 122, 0.45);
+  border-radius: var(--radius-md);
+}
+
+.payment-method__radio:checked + .payment-method__header .payment-method__summary {
+  color: var(--text);
+}
+
+.payment-method__radio:checked + .payment-method__header + .payment-method__panel {
+  display: grid;
+}
+
+.order-status {
+  display: grid;
+  gap: 1.4rem;
+  text-align: center;
+  padding: 3rem 2rem;
+}
+
+.order-status__symbol {
+  width: 84px;
+  height: 84px;
+  border-radius: 50%;
+  margin: 0 auto;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, rgba(214, 167, 122, 0.5), rgba(214, 167, 122, 0.8));
+  color: #fff;
+  font-size: 2rem;
+}
+
+.order-status h2 {
+  font-family: "Noto Serif JP", serif;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  margin: 0;
+}
+
+.order-status p {
+  color: var(--muted);
+  margin: 0 auto;
+  max-width: 420px;
+}
+
+footer {
+  padding: 3rem 0 2rem;
+  color: var(--muted);
+  font-size: 0.85rem;
+  text-align: center;
+}
+
+footer a {
+  color: inherit;
+}
+
+@media (max-width: 640px) {
+  header {
+    padding: 2rem 0 1rem;
+  }
+
+  .progress {
+    gap: 0.5rem;
+  }
+
+  .progress__step {
+    padding: 0.55rem 0.8rem;
+  }
+
+  .card {
+    padding: 1.5rem;
+  }
+
+  .coupon-form .coupon-inputs {
+    flex-direction: column;
+  }
+}

--- a/cart.html
+++ b/cart.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>購物車 | Hikari Atelier</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@400;500;600&family=Zen+Kaku+Gothic+New:wght@400;500&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="assets/css/checkout.css" />
+  </head>
+  <body>
+    <header>
+      <div class="wrapper">
+        <div class="brand">
+          <span class="brand__symbol">光</span>
+          <div class="brand__title">Hikari Atelier</div>
+        </div>
+        <ol class="progress">
+          <li class="progress__step progress__step--current">
+            <span class="progress__index">1</span>
+            購物車
+          </li>
+          <li class="progress__step">
+            <span class="progress__index">2</span>
+            確認訂單內容
+          </li>
+          <li class="progress__step">
+            <span class="progress__index">3</span>
+            結帳
+          </li>
+          <li class="progress__step">
+            <span class="progress__index">4</span>
+            完成
+          </li>
+        </ol>
+      </div>
+    </header>
+    <main>
+      <section class="section">
+        <div class="wrapper">
+          <h1>購物車</h1>
+          <p class="lead">
+            請從容挑選那些映著柔光的日常器物，您可隨時調整數量與款式。
+          </p>
+          <div class="card">
+            <table class="table" aria-label="購物車內容">
+              <thead>
+                <tr>
+                  <th scope="col">商品</th>
+                  <th scope="col">選項</th>
+                  <th scope="col">數量</th>
+                  <th scope="col">小計</th>
+                  <th scope="col" class="visually-hidden">操作</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    <strong>櫻香護手霜</strong>
+                    <div class="note">柔和的花香與清爽的質地</div>
+                  </td>
+                  <td>櫻花 / 50g</td>
+                  <td>
+                    <div class="quantity-control" role="group" aria-label="櫻香護手霜 數量">
+                      <button type="button" aria-label="減少數量">−</button>
+                      <input type="number" value="2" min="1" inputmode="numeric" aria-live="polite" />
+                      <button type="button" aria-label="增加數量">＋</button>
+                    </div>
+                  </td>
+                  <td>¥3,960</td>
+                  <td class="product-actions">
+                    <a class="remove-link" href="#" aria-label="移除櫻香護手霜">
+                      <span aria-hidden="true">✕</span>
+                      移除
+                    </a>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <strong>透花馬克杯</strong>
+                    <div class="note">手作釉藥映襯出輕巧杯身</div>
+                  </td>
+                  <td>霧青</td>
+                  <td>
+                    <div class="quantity-control" role="group" aria-label="透花馬克杯 數量">
+                      <button type="button" aria-label="減少數量">−</button>
+                      <input type="number" value="1" min="1" inputmode="numeric" aria-live="polite" />
+                      <button type="button" aria-label="增加數量">＋</button>
+                    </div>
+                  </td>
+                  <td>¥2,860</td>
+                  <td class="product-actions">
+                    <a class="remove-link" href="#" aria-label="移除透花馬克杯">
+                      <span aria-hidden="true">✕</span>
+                      移除
+                    </a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <div class="summary-list">
+              <div class="summary-row">
+                <span>小計</span>
+                <span>¥6,820</span>
+              </div>
+              <div class="summary-row">
+                <span>運費</span>
+                <span>¥550</span>
+              </div>
+              <div class="summary-row">
+                <span>折價卷</span>
+                <span>−¥0</span>
+              </div>
+              <div class="summary-row summary-row--total">
+                <span>合計</span>
+                <span>¥7,370</span>
+              </div>
+            </div>
+            <form class="coupon-form" aria-label="折價卷">
+              <label for="coupon-code">擁有折價卷嗎？</label>
+              <div class="coupon-inputs">
+                <input
+                  class="input"
+                  id="coupon-code"
+                  name="coupon-code"
+                  type="text"
+                  placeholder="輸入折扣代碼"
+                  autocomplete="off"
+                />
+                <button class="btn btn--ghost" type="submit">套用折扣</button>
+              </div>
+              <p class="note">※ 善用折扣代碼，讓美好生活更貼近日常。</p>
+            </form>
+            <div class="actions">
+              <a class="btn btn--ghost" href="index.html">繼續購物</a>
+              <a class="btn btn--primary" href="order-confirmation.html">前往確認訂單</a>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer>
+      <div class="wrapper">&copy; 2024 Hikari Atelier. 為您送上溫柔的生活風景。</div>
+    </footer>
+  </body>
+</html>

--- a/checkout.html
+++ b/checkout.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>結帳 | Hikari Atelier</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@400;500;600&family=Zen+Kaku+Gothic+New:wght@400;500&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="assets/css/checkout.css" />
+  </head>
+  <body>
+    <header>
+      <div class="wrapper">
+        <div class="brand">
+          <span class="brand__symbol">光</span>
+          <div class="brand__title">Hikari Atelier</div>
+        </div>
+        <ol class="progress">
+          <li class="progress__step">
+            <span class="progress__index">1</span>
+            購物車
+          </li>
+          <li class="progress__step">
+            <span class="progress__index">2</span>
+            確認訂單內容
+          </li>
+          <li class="progress__step progress__step--current">
+            <span class="progress__index">3</span>
+            結帳
+          </li>
+          <li class="progress__step">
+            <span class="progress__index">4</span>
+            完成
+          </li>
+        </ol>
+      </div>
+    </header>
+    <main>
+      <section class="section">
+        <div class="wrapper">
+          <h1>選擇付款方式</h1>
+          <p class="lead">
+            為守護您的安心，卡片資訊將以加密方式傳送，請放心慢慢填寫。
+          </p>
+          <div class="card">
+            <h2>付款方式</h2>
+            <form class="payment-methods" aria-label="付款方式">
+              <div class="payment-method">
+                <input class="payment-method__radio" type="radio" name="payment-method" id="method-card" checked />
+                <label class="payment-method__header" for="method-card">
+                  <span class="payment-method__title">
+                    <span class="payment-method__icon" aria-hidden="true">💳</span>
+                    信用卡
+                  </span>
+                  <span class="payment-method__summary">支援 Visa / Mastercard / JCB</span>
+                </label>
+                <div class="payment-method__panel" aria-live="polite">
+                  <div class="form-grid" aria-label="信用卡資訊">
+                    <label class="label" for="card-name">持卡人姓名</label>
+                    <input class="input" id="card-name" name="card-name" type="text" placeholder="YAMAMOTO MISAKI" />
+                    <div class="form-grid form-grid--two">
+                      <div>
+                        <label class="label" for="card-number">卡號</label>
+                        <input class="input" id="card-number" name="card-number" type="text" inputmode="numeric" placeholder="1234 5678 9012 3456" />
+                      </div>
+                      <div>
+                        <label class="label" for="card-exp">有效期限</label>
+                        <input class="input" id="card-exp" name="card-exp" type="text" placeholder="05 / 26" />
+                      </div>
+                    </div>
+                    <div class="form-grid form-grid--two">
+                      <div>
+                        <label class="label" for="card-cvc">安全碼</label>
+                        <input class="input" id="card-cvc" name="card-cvc" type="password" inputmode="numeric" placeholder="***" />
+                      </div>
+                      <div>
+                        <label class="label" for="card-zip">郵遞區號</label>
+                        <input class="input" id="card-zip" name="card-zip" type="text" inputmode="numeric" placeholder="1500001" />
+                      </div>
+                    </div>
+                  </div>
+                  <p class="note">※ 您填寫的內容將於金流合作夥伴的安全伺服器中處理。</p>
+                </div>
+              </div>
+              <div class="payment-method">
+                <input class="payment-method__radio" type="radio" name="payment-method" id="method-bank" />
+                <label class="payment-method__header" for="method-bank">
+                  <span class="payment-method__title">
+                    <span class="payment-method__icon" aria-hidden="true">🏦</span>
+                    銀行轉帳
+                  </span>
+                  <span class="payment-method__summary">下單後3日內完成匯款即可</span>
+                </label>
+                <div class="payment-method__panel">
+                  <p class="note">請於 3 個工作天內轉帳至下列帳戶，並於備註留下訂單編號以利對帳：</p>
+                  <div class="summary-list">
+                    <div class="summary-row">
+                      <span>銀行</span>
+                      <span>瑞穗銀行 澀谷支店（店號132）</span>
+                    </div>
+                    <div class="summary-row">
+                      <span>帳號</span>
+                      <span>普通 1234567</span>
+                    </div>
+                    <div class="summary-row">
+                      <span>戶名</span>
+                      <span>ヒカリアトリエ合同会社</span>
+                    </div>
+                  </div>
+                  <p class="note">※ 匯款完成後，我們將寄送信件通知安排出貨。</p>
+                </div>
+              </div>
+              <div class="payment-method">
+                <input class="payment-method__radio" type="radio" name="payment-method" id="method-mobile" />
+                <label class="payment-method__header" for="method-mobile">
+                  <span class="payment-method__title">
+                    <span class="payment-method__icon" aria-hidden="true">📱</span>
+                    行動支付
+                  </span>
+                  <span class="payment-method__summary">支援 Apple Pay、LINE Pay、PayPay</span>
+                </label>
+                <div class="payment-method__panel">
+                  <p class="note">選擇行動支付後，確認送出訂單即會引導至合作支付頁面完成交易。</p>
+                  <p class="note">※ 為確保交易順利，請事先確認您的裝置已綁定對應卡片或帳戶。</p>
+                </div>
+              </div>
+            </form>
+          </div>
+          <div class="card">
+            <h2>帳單資訊</h2>
+            <form class="form-grid form-grid--two" aria-label="帳單資訊">
+              <div>
+                <label class="label" for="billing-name">姓名</label>
+                <input class="input" id="billing-name" name="billing-name" type="text" placeholder="山本 美咲" />
+              </div>
+              <div>
+                <label class="label" for="billing-phone">聯絡電話</label>
+                <input class="input" id="billing-phone" name="billing-phone" type="tel" placeholder="090-1234-5678" />
+              </div>
+              <div>
+                <label class="label" for="billing-address">地址</label>
+                <input class="input" id="billing-address" name="billing-address" type="text" placeholder="東京都澀谷區神宮前1-1-1 光之露台501" />
+              </div>
+              <div>
+                <label class="label" for="billing-notes">備註</label>
+                <input class="input" id="billing-notes" name="billing-notes" type="text" placeholder="若需客製賀卡或熨斗，請在此填寫" />
+              </div>
+            </form>
+            <div class="actions">
+              <a class="btn btn--ghost" href="order-confirmation.html">返回</a>
+              <a class="btn btn--primary" href="order-complete.html">確認送出訂單</a>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer>
+      <div class="wrapper">&copy; 2024 Hikari Atelier. 為您送上溫柔的生活風景。</div>
+    </footer>
+  </body>
+</html>

--- a/order-complete.html
+++ b/order-complete.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>訂單完成 | Hikari Atelier</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@400;500;600&family=Zen+Kaku+Gothic+New:wght@400;500&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="assets/css/checkout.css" />
+  </head>
+  <body>
+    <header>
+      <div class="wrapper">
+        <div class="brand">
+          <span class="brand__symbol">光</span>
+          <div class="brand__title">Hikari Atelier</div>
+        </div>
+        <ol class="progress">
+          <li class="progress__step">
+            <span class="progress__index">1</span>
+            購物車
+          </li>
+          <li class="progress__step">
+            <span class="progress__index">2</span>
+            確認訂單內容
+          </li>
+          <li class="progress__step">
+            <span class="progress__index">3</span>
+            結帳
+          </li>
+          <li class="progress__step progress__step--current">
+            <span class="progress__index">4</span>
+            完成
+          </li>
+        </ol>
+      </div>
+    </header>
+    <main>
+      <section class="section">
+        <div class="wrapper">
+          <h1>感謝您的訂購</h1>
+          <p class="lead">
+            已寄出確認信至您留下的電子信箱，敬請稍候靜待商品送達。
+          </p>
+          <div class="card order-status">
+            <div class="order-status__symbol" aria-hidden="true">◎</div>
+            <h2>訂單編號：HA-20240501-872</h2>
+            <p>
+              精心挑選的好物即將啟程前往您的身邊，待出貨完成後我們會再以電子郵件通知。
+            </p>
+            <div class="actions" style="justify-content: center">
+              <a class="btn btn--primary" href="index.html">返回首頁</a>
+              <a class="btn btn--ghost" href="cart.html">再次前往選購</a>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer>
+      <div class="wrapper">&copy; 2024 Hikari Atelier. 為您送上溫柔的生活風景。</div>
+    </footer>
+  </body>
+</html>

--- a/order-confirmation.html
+++ b/order-confirmation.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>確認訂單內容 | Hikari Atelier</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@400;500;600&family=Zen+Kaku+Gothic+New:wght@400;500&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="assets/css/checkout.css" />
+  </head>
+  <body>
+    <header>
+      <div class="wrapper">
+        <div class="brand">
+          <span class="brand__symbol">光</span>
+          <div class="brand__title">Hikari Atelier</div>
+        </div>
+        <ol class="progress">
+          <li class="progress__step">
+            <span class="progress__index">1</span>
+            購物車
+          </li>
+          <li class="progress__step progress__step--current">
+            <span class="progress__index">2</span>
+            確認訂單內容
+          </li>
+          <li class="progress__step">
+            <span class="progress__index">3</span>
+            結帳
+          </li>
+          <li class="progress__step">
+            <span class="progress__index">4</span>
+            完成
+          </li>
+        </ol>
+      </div>
+    </header>
+    <main>
+      <section class="section">
+        <div class="wrapper">
+          <h1>請確認訂單內容</h1>
+          <p class="lead">
+            請檢視收件資訊、配送方式與禮品需求，從容再確認一次是否無誤。
+          </p>
+          <div class="card">
+            <div class="card__header">
+              <h2>收件資訊</h2>
+              <a class="btn btn--icon" href="#" aria-label="修改收件資訊">
+                <span aria-hidden="true">✎</span>
+                修改資訊
+              </a>
+            </div>
+            <div class="summary-list">
+              <div class="summary-row">
+                <span>姓名</span>
+                <span>山本 美咲 小姐</span>
+              </div>
+              <div class="summary-row">
+                <span>地址</span>
+                <span>150-0001 東京都澀谷區神宮前1-1-1 光之露台501室</span>
+              </div>
+              <div class="summary-row">
+                <span>配送時間</span>
+                <span>5月12日（週日）上午</span>
+              </div>
+              <div class="summary-row">
+                <span>禮品包裝</span>
+                <span>需要（和紙包裝）</span>
+              </div>
+            </div>
+          </div>
+          <div class="card">
+            <h2>訂購商品</h2>
+            <table class="table" aria-label="訂購商品明細">
+              <thead>
+                <tr>
+                  <th scope="col">商品</th>
+                  <th scope="col">數量</th>
+                  <th scope="col">小計</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>櫻香護手霜（櫻花 / 50g）</td>
+                  <td>2</td>
+                  <td>¥3,960</td>
+                </tr>
+                <tr>
+                  <td>透花馬克杯（霧青）</td>
+                  <td>1</td>
+                  <td>¥2,860</td>
+                </tr>
+              </tbody>
+            </table>
+            <div class="summary-list">
+              <div class="summary-row">
+                <span>小計</span>
+                <span>¥6,820</span>
+              </div>
+              <div class="summary-row">
+                <span>運費</span>
+                <span>¥550</span>
+              </div>
+              <div class="summary-row">
+                <span>禮品包裝</span>
+                <span>¥330</span>
+              </div>
+              <div class="summary-row summary-row--total">
+                <span>合計</span>
+                <span>¥7,700</span>
+              </div>
+            </div>
+            <div class="actions">
+              <a class="btn btn--ghost" href="cart.html">返回修改</a>
+              <a class="btn btn--primary" href="checkout.html">前往結帳</a>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+    <footer>
+      <div class="wrapper">&copy; 2024 Hikari Atelier. 為您送上溫柔的生活風景。</div>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- convert the header wrapper into a flex row so the brand and checkout流程 align on one line
- anchor the progress list to the right edge while preserving wrap and spacing on narrow screens

## Testing
- not run (static content change)

------
https://chatgpt.com/codex/tasks/task_e_68df7cc0a6fc832c840b9cdd58f35399