### PR TITLE
Switch site to a minimalist Japanese-inspired light theme

### DIFF
--- a/assets/css/about.css
+++ b/assets/css/about.css
@@ -4,12 +4,12 @@ body {
 }
 
 .site-header--plain {
-  background: rgba(255, 255, 255, 0.92);
+  background: rgba(255, 255, 255, 0.9);
   border-bottom: 1px solid var(--color-border);
   position: sticky;
   top: 0;
   z-index: 50;
-  box-shadow: 0 1px 0 rgba(133, 104, 89, 0.12);
+  box-shadow: 0 1px 0 rgba(20, 31, 49, 0.1);
 }
 
 .page-hero {
@@ -32,7 +32,7 @@ body {
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(120deg, rgba(245, 242, 232, 0.88), rgba(203, 27, 69, 0.26));
+  background: linear-gradient(120deg, rgba(24, 34, 50, 0.8), rgba(196, 160, 82, 0.28));
 }
 
 .page-hero__media img {
@@ -158,28 +158,28 @@ body {
   height: 96px;
   margin: 0 auto;
   border-radius: 32px;
-  background: linear-gradient(135deg, rgba(203, 27, 69, 0.22), rgba(221, 183, 160, 0.42));
+  background: linear-gradient(135deg, rgba(31, 43, 61, 0.26), rgba(196, 160, 82, 0.4));
 }
 
 .team-card__avatar--lead {
-  background-image: linear-gradient(135deg, #e16b8c, #fdede5);
+  background-image: linear-gradient(135deg, #2f3e52, #172233);
 }
 
 .team-card__avatar--coach {
-  background-image: linear-gradient(135deg, #7db9de, #fcfaf2);
+  background-image: linear-gradient(135deg, #1f3b4a, #11232d);
 }
 
 .team-card__avatar--performance {
-  background-image: linear-gradient(135deg, #a8d8b9, #fcfaf2);
+  background-image: linear-gradient(135deg, #23362d, #101b16);
 }
 
 .team-card__avatar--community {
-  background-image: linear-gradient(135deg, #bb8bce, #fcfaf2);
+  background-image: linear-gradient(135deg, #2e2f3f, #161a24);
 }
 
 .cta {
-  background: linear-gradient(120deg, rgba(203, 27, 69, 0.24), rgba(248, 181, 0, 0.42));
-  color: var(--color-ink);
+  background: linear-gradient(120deg, rgba(20, 31, 49, 0.9), rgba(196, 160, 82, 0.42));
+  color: #f7f6f2;
 }
 
 .cta__inner {

--- a/assets/css/about.css
+++ b/assets/css/about.css
@@ -1,6 +1,6 @@
 body {
   background: var(--color-background);
-  color: #2f2a26;
+  color: var(--color-ink);
 }
 
 .site-header--plain {
@@ -9,7 +9,7 @@ body {
   position: sticky;
   top: 0;
   z-index: 50;
-  box-shadow: 0 1px 0 rgba(53, 68, 83, 0.06);
+  box-shadow: 0 1px 0 rgba(133, 104, 89, 0.12);
 }
 
 .page-hero {
@@ -32,7 +32,7 @@ body {
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(120deg, rgba(247, 242, 235, 0.85), rgba(209, 73, 91, 0.28));
+  background: linear-gradient(120deg, rgba(245, 242, 232, 0.88), rgba(203, 27, 69, 0.26));
 }
 
 .page-hero__media img {
@@ -158,28 +158,28 @@ body {
   height: 96px;
   margin: 0 auto;
   border-radius: 32px;
-  background: linear-gradient(135deg, rgba(209, 73, 91, 0.18), rgba(232, 167, 93, 0.4));
+  background: linear-gradient(135deg, rgba(203, 27, 69, 0.22), rgba(221, 183, 160, 0.42));
 }
 
 .team-card__avatar--lead {
-  background-image: linear-gradient(135deg, #f5c8b8, #f8f2eb);
+  background-image: linear-gradient(135deg, #e16b8c, #fdede5);
 }
 
 .team-card__avatar--coach {
-  background-image: linear-gradient(135deg, #c4dce6, #f7f2eb);
+  background-image: linear-gradient(135deg, #7db9de, #fcfaf2);
 }
 
 .team-card__avatar--performance {
-  background-image: linear-gradient(135deg, #c8e0c0, #f7f4ee);
+  background-image: linear-gradient(135deg, #a8d8b9, #fcfaf2);
 }
 
 .team-card__avatar--community {
-  background-image: linear-gradient(135deg, #d8cee6, #faf6ef);
+  background-image: linear-gradient(135deg, #bb8bce, #fcfaf2);
 }
 
 .cta {
-  background: linear-gradient(120deg, rgba(209, 73, 91, 0.2), rgba(232, 167, 93, 0.45));
-  color: #2f2a26;
+  background: linear-gradient(120deg, rgba(203, 27, 69, 0.24), rgba(248, 181, 0, 0.42));
+  color: var(--color-ink);
 }
 
 .cta__inner {

--- a/assets/css/about.css
+++ b/assets/css/about.css
@@ -1,14 +1,15 @@
 body {
   background: var(--color-background);
-  color: #f8fafc;
+  color: #2f2a26;
 }
 
 .site-header--plain {
-  background: rgba(6, 11, 26, 0.92);
-  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(255, 255, 255, 0.92);
+  border-bottom: 1px solid var(--color-border);
   position: sticky;
   top: 0;
   z-index: 50;
+  box-shadow: 0 1px 0 rgba(53, 68, 83, 0.06);
 }
 
 .page-hero {
@@ -31,7 +32,7 @@ body {
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(120deg, rgba(6, 11, 26, 0.25), rgba(6, 11, 26, 0.82));
+  background: linear-gradient(120deg, rgba(247, 242, 235, 0.85), rgba(209, 73, 91, 0.28));
 }
 
 .page-hero__media img {
@@ -157,27 +158,28 @@ body {
   height: 96px;
   margin: 0 auto;
   border-radius: 32px;
-  background: linear-gradient(135deg, rgba(255, 95, 60, 0.6), rgba(15, 23, 42, 0.95));
+  background: linear-gradient(135deg, rgba(209, 73, 91, 0.18), rgba(232, 167, 93, 0.4));
 }
 
 .team-card__avatar--lead {
-  background-image: linear-gradient(135deg, #f97316, #111827);
+  background-image: linear-gradient(135deg, #f5c8b8, #f8f2eb);
 }
 
 .team-card__avatar--coach {
-  background-image: linear-gradient(135deg, #38bdf8, #0f172a);
+  background-image: linear-gradient(135deg, #c4dce6, #f7f2eb);
 }
 
 .team-card__avatar--performance {
-  background-image: linear-gradient(135deg, #22d3ee, #1f2937);
+  background-image: linear-gradient(135deg, #c8e0c0, #f7f4ee);
 }
 
 .team-card__avatar--community {
-  background-image: linear-gradient(135deg, #a855f7, #111827);
+  background-image: linear-gradient(135deg, #d8cee6, #faf6ef);
 }
 
 .cta {
-  background: linear-gradient(120deg, rgba(255, 95, 60, 0.65), rgba(6, 11, 26, 0.95));
+  background: linear-gradient(120deg, rgba(209, 73, 91, 0.2), rgba(232, 167, 93, 0.45));
+  color: #2f2a26;
 }
 
 .cta__inner {
@@ -194,8 +196,10 @@ body {
 }
 
 .site-footer {
-  background: #050a1a;
+  background: var(--color-card);
   padding: 32px 0;
+  border-top: 1px solid var(--color-border);
+  color: var(--color-muted);
 }
 
 @media (max-width: 768px) {

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1,20 +1,20 @@
 :root {
-  --color-primary: #cb1b45;
-  --color-primary-dark: #ba2636;
-  --color-accent: #f8b500;
-  --color-surface: #fcfaf2;
-  --color-surface-alt: #f5f2e8;
-  --color-muted: #856859;
-  --color-muted-light: #ddb7a0;
-  --color-border: rgba(133, 104, 89, 0.22);
-  --color-background: #fcfaf2;
-  --color-section: #dcd3b2;
-  --color-card: #fcfaf2;
-  --color-card-alt: #d9d6c3;
-  --color-highlight: rgba(203, 27, 69, 0.14);
-  --gradient-hero: linear-gradient(135deg, rgba(203, 27, 69, 0.22), rgba(252, 250, 242, 0.94));
-  --gradient-card: linear-gradient(160deg, rgba(221, 183, 160, 0.3), rgba(252, 250, 242, 0.96));
-  --color-ink: #434343;
+  --color-primary: #1f2b3d;
+  --color-primary-dark: #141d2b;
+  --color-accent: #c4a052;
+  --color-surface: #f5f6f4;
+  --color-surface-alt: #edeff1;
+  --color-muted: #5c6473;
+  --color-muted-light: #8f99a8;
+  --color-border: rgba(31, 43, 61, 0.16);
+  --color-background: #f5f6f4;
+  --color-section: #eaecf0;
+  --color-card: #ffffff;
+  --color-card-alt: #e3e6eb;
+  --color-highlight: rgba(196, 160, 82, 0.16);
+  --gradient-hero: linear-gradient(135deg, rgba(20, 31, 49, 0.78), rgba(245, 246, 244, 0.92));
+  --gradient-card: linear-gradient(150deg, rgba(31, 43, 61, 0.12), rgba(196, 160, 82, 0.22));
+  --color-ink: #1c2432;
   --font-base: 'Barlow', 'Noto Sans TC', sans-serif;
   --font-display: 'Rajdhani', 'Noto Sans TC', sans-serif;
   --container-width: min(1156px, 100% - 48px);
@@ -22,9 +22,9 @@
   --radius-lg: 28px;
   --radius-md: 20px;
   --radius-sm: 12px;
-  --shadow-soft: 0 24px 48px rgba(67, 61, 60, 0.16);
-  --shadow-card: 0 18px 36px rgba(67, 61, 60, 0.14);
-  --shadow-elevated: 0 28px 52px rgba(67, 61, 60, 0.18);
+  --shadow-soft: 0 24px 48px rgba(20, 31, 49, 0.18);
+  --shadow-card: 0 18px 36px rgba(20, 31, 49, 0.14);
+  --shadow-elevated: 0 28px 52px rgba(20, 31, 49, 0.2);
   color-scheme: light;
 }
 

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1,19 +1,19 @@
 :root {
-  --color-primary: #ff5f3c;
-  --color-primary-dark: #e14c2b;
-  --color-accent: #ffd166;
+  --color-primary: #d1495b;
+  --color-primary-dark: #b13b48;
+  --color-accent: #e8a75d;
   --color-surface: #ffffff;
-  --color-surface-alt: #0c1324;
-  --color-muted: #64748b;
-  --color-muted-light: #94a3b8;
-  --color-border: rgba(255, 255, 255, 0.16);
-  --color-background: #060b1a;
-  --color-section: #0f172a;
-  --color-card: #101a32;
-  --color-card-alt: #13203a;
-  --color-highlight: rgba(255, 209, 102, 0.08);
-  --gradient-hero: linear-gradient(135deg, rgba(255, 95, 60, 0.9), rgba(6, 11, 26, 0.92));
-  --gradient-card: linear-gradient(160deg, rgba(255, 95, 60, 0.18), rgba(6, 11, 26, 0.8));
+  --color-surface-alt: #f5ede1;
+  --color-muted: #6f7783;
+  --color-muted-light: #99a4b1;
+  --color-border: rgba(53, 68, 83, 0.16);
+  --color-background: #f7f2eb;
+  --color-section: #f2ece4;
+  --color-card: #ffffff;
+  --color-card-alt: #f9f5ef;
+  --color-highlight: rgba(209, 73, 91, 0.12);
+  --gradient-hero: linear-gradient(135deg, rgba(209, 73, 91, 0.25), rgba(255, 255, 255, 0.92));
+  --gradient-card: linear-gradient(160deg, rgba(232, 167, 93, 0.16), rgba(255, 255, 255, 0.96));
   --font-base: 'Barlow', 'Noto Sans TC', sans-serif;
   --font-display: 'Rajdhani', 'Noto Sans TC', sans-serif;
   --container-width: min(1156px, 100% - 48px);
@@ -21,9 +21,9 @@
   --radius-lg: 28px;
   --radius-md: 20px;
   --radius-sm: 12px;
-  --shadow-soft: 0 20px 60px rgba(4, 9, 20, 0.35);
-  --shadow-card: 0 12px 40px rgba(4, 9, 20, 0.25);
-  color-scheme: dark light;
+  --shadow-soft: 0 24px 48px rgba(62, 70, 85, 0.16);
+  --shadow-card: 0 18px 36px rgba(62, 70, 85, 0.14);
+  color-scheme: light;
 }
 
 * {
@@ -40,7 +40,7 @@ body {
   margin: 0;
   font-family: var(--font-base);
   background-color: var(--color-background);
-  color: #f8fafc;
+  color: #2f2a26;
   line-height: 1.6;
 }
 
@@ -51,7 +51,7 @@ a {
 
 a:hover,
 a:focus {
-  color: var(--color-accent);
+  color: var(--color-primary);
 }
 
 img,
@@ -85,7 +85,7 @@ section {
   left: -999px;
   top: 16px;
   background: var(--color-accent);
-  color: #0f172a;
+  color: #2f2a26;
   padding: 12px 18px;
   border-radius: 999px;
   font-weight: 600;

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1,19 +1,20 @@
 :root {
-  --color-primary: #d1495b;
-  --color-primary-dark: #b13b48;
-  --color-accent: #e8a75d;
-  --color-surface: #ffffff;
-  --color-surface-alt: #f5ede1;
-  --color-muted: #6f7783;
-  --color-muted-light: #99a4b1;
-  --color-border: rgba(53, 68, 83, 0.16);
-  --color-background: #f7f2eb;
-  --color-section: #f2ece4;
-  --color-card: #ffffff;
-  --color-card-alt: #f9f5ef;
-  --color-highlight: rgba(209, 73, 91, 0.12);
-  --gradient-hero: linear-gradient(135deg, rgba(209, 73, 91, 0.25), rgba(255, 255, 255, 0.92));
-  --gradient-card: linear-gradient(160deg, rgba(232, 167, 93, 0.16), rgba(255, 255, 255, 0.96));
+  --color-primary: #cb1b45;
+  --color-primary-dark: #ba2636;
+  --color-accent: #f8b500;
+  --color-surface: #fcfaf2;
+  --color-surface-alt: #f5f2e8;
+  --color-muted: #856859;
+  --color-muted-light: #ddb7a0;
+  --color-border: rgba(133, 104, 89, 0.22);
+  --color-background: #fcfaf2;
+  --color-section: #dcd3b2;
+  --color-card: #fcfaf2;
+  --color-card-alt: #d9d6c3;
+  --color-highlight: rgba(203, 27, 69, 0.14);
+  --gradient-hero: linear-gradient(135deg, rgba(203, 27, 69, 0.22), rgba(252, 250, 242, 0.94));
+  --gradient-card: linear-gradient(160deg, rgba(221, 183, 160, 0.3), rgba(252, 250, 242, 0.96));
+  --color-ink: #434343;
   --font-base: 'Barlow', 'Noto Sans TC', sans-serif;
   --font-display: 'Rajdhani', 'Noto Sans TC', sans-serif;
   --container-width: min(1156px, 100% - 48px);
@@ -21,8 +22,9 @@
   --radius-lg: 28px;
   --radius-md: 20px;
   --radius-sm: 12px;
-  --shadow-soft: 0 24px 48px rgba(62, 70, 85, 0.16);
-  --shadow-card: 0 18px 36px rgba(62, 70, 85, 0.14);
+  --shadow-soft: 0 24px 48px rgba(67, 61, 60, 0.16);
+  --shadow-card: 0 18px 36px rgba(67, 61, 60, 0.14);
+  --shadow-elevated: 0 28px 52px rgba(67, 61, 60, 0.18);
   color-scheme: light;
 }
 
@@ -40,7 +42,7 @@ body {
   margin: 0;
   font-family: var(--font-base);
   background-color: var(--color-background);
-  color: #2f2a26;
+  color: var(--color-ink);
   line-height: 1.6;
 }
 
@@ -85,7 +87,7 @@ section {
   left: -999px;
   top: 16px;
   background: var(--color-accent);
-  color: #2f2a26;
+  color: var(--color-ink);
   padding: 12px 18px;
   border-radius: 999px;
   font-weight: 600;

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -1,7 +1,7 @@
 .topbar {
-  background: rgba(15, 23, 42, 0.85);
-  backdrop-filter: blur(10px);
-  border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--color-border);
   font-size: 0.875rem;
 }
 
@@ -16,12 +16,12 @@
 .topbar__contact {
   display: flex;
   gap: 24px;
-  color: var(--color-muted-light);
+  color: var(--color-muted);
 }
 
 .topbar__contact a:hover,
 .topbar__contact a:focus {
-  color: #fff;
+  color: var(--color-primary);
 }
 
 .social-list {
@@ -41,9 +41,10 @@
   position: sticky;
   top: 0;
   z-index: 50;
-  background: rgba(6, 11, 26, 0.92);
-  backdrop-filter: blur(16px);
-  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(18px);
+  border-bottom: 1px solid var(--color-border);
+  box-shadow: 0 1px 0 rgba(53, 68, 83, 0.06);
 }
 
 .site-header__inner {
@@ -70,6 +71,7 @@
   place-items: center;
   border-radius: 12px;
   background: var(--gradient-hero);
+  color: #2f2a26;
   font-family: var(--font-display);
   font-size: 1.2rem;
 }
@@ -81,8 +83,8 @@
 .site-nav__toggle {
   display: none;
   background: transparent;
-  color: #fff;
-  border: 1px solid rgba(148, 163, 184, 0.4);
+  color: #2f2a26;
+  border: 1px solid var(--color-border);
   padding: 8px 16px;
   border-radius: 999px;
   font-weight: 600;
@@ -109,7 +111,7 @@
 
 .site-nav__list a:hover,
 .site-nav__list a:focus {
-  color: var(--color-accent);
+  color: var(--color-primary);
 }
 
 .btn {
@@ -133,7 +135,7 @@
 
 .btn--accent {
   background: var(--color-accent);
-  color: #0f172a;
+  color: #3f2c1d;
   padding: 12px 28px;
 }
 
@@ -147,26 +149,28 @@
   background: var(--color-primary);
   color: #fff;
   padding: 12px 32px;
+  box-shadow: var(--shadow-card);
 }
 
 .btn--primary:hover,
 .btn--primary:focus {
   background: var(--color-primary-dark);
   transform: translateY(-2px);
-  box-shadow: var(--shadow-card);
+  box-shadow: var(--shadow-soft);
 }
 
 .btn--ghost {
   background: transparent;
-  color: #fff;
+  color: var(--color-primary);
   padding: 12px 28px;
-  border: 1px solid rgba(255, 255, 255, 0.35);
+  border: 1px solid rgba(209, 73, 91, 0.35);
 }
 
 .btn--ghost:hover,
 .btn--ghost:focus {
-  border-color: var(--color-accent);
-  color: var(--color-accent);
+  border-color: var(--color-primary);
+  color: var(--color-primary-dark);
+  background: rgba(209, 73, 91, 0.06);
 }
 
 .section-head {
@@ -215,9 +219,9 @@
   letter-spacing: 0.12em;
   text-transform: uppercase;
   font-weight: 600;
-  color: rgba(226, 232, 240, 0.8);
-  background: rgba(15, 23, 42, 0.6);
-  backdrop-filter: blur(8px);
+  color: var(--color-muted);
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(6px);
 }
 
 .image-note--overlay {
@@ -233,7 +237,7 @@
   background: transparent;
   padding: 0;
   letter-spacing: 0.08em;
-  color: rgba(148, 163, 184, 0.85);
+  color: rgba(111, 118, 129, 0.85);
 }
 
 @media (max-width: 1024px) {
@@ -266,10 +270,11 @@
     position: absolute;
     inset: 72px 16px auto;
     flex-direction: column;
-    background: rgba(6, 11, 26, 0.96);
+    background: rgba(255, 255, 255, 0.98);
     padding: 20px;
     border-radius: var(--radius-md);
     box-shadow: var(--shadow-soft);
+    border: 1px solid var(--color-border);
     transform-origin: top right;
     transform: scale(0.9);
     opacity: 0;

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -1,6 +1,6 @@
 .topbar {
-  background: rgba(255, 255, 255, 0.85);
-  backdrop-filter: blur(12px);
+  background: rgba(255, 255, 255, 0.82);
+  backdrop-filter: blur(14px);
   border-bottom: 1px solid var(--color-border);
   font-size: 0.875rem;
 }
@@ -41,10 +41,10 @@
   position: sticky;
   top: 0;
   z-index: 50;
-  background: rgba(255, 255, 255, 0.92);
-  backdrop-filter: blur(18px);
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(20px);
   border-bottom: 1px solid var(--color-border);
-  box-shadow: 0 1px 0 rgba(133, 104, 89, 0.12);
+  box-shadow: 0 1px 0 rgba(20, 31, 49, 0.1);
 }
 
 .site-header__inner {
@@ -70,10 +70,11 @@
   display: grid;
   place-items: center;
   border-radius: 12px;
-  background: var(--gradient-hero);
-  color: var(--color-ink);
+  background: linear-gradient(135deg, rgba(31, 43, 61, 0.92), rgba(196, 160, 82, 0.6));
+  color: #fff;
   font-family: var(--font-display);
   font-size: 1.2rem;
+  box-shadow: 0 10px 18px rgba(20, 31, 49, 0.18);
 }
 
 .site-nav {
@@ -84,7 +85,7 @@
   display: none;
   background: transparent;
   color: var(--color-ink);
-  border: 1px solid var(--color-border);
+  border: 1px solid rgba(31, 43, 61, 0.24);
   padding: 8px 16px;
   border-radius: 999px;
   font-weight: 600;
@@ -135,14 +136,15 @@
 
 .btn--accent {
   background: var(--color-accent);
-  color: #6b3b2a;
+  color: #1f2b3d;
   padding: 12px 28px;
+  box-shadow: var(--shadow-card);
 }
 
 .btn--accent:hover,
 .btn--accent:focus {
   transform: translateY(-2px);
-  box-shadow: var(--shadow-card);
+  box-shadow: var(--shadow-soft);
 }
 
 .btn--primary {
@@ -163,14 +165,14 @@
   background: transparent;
   color: var(--color-primary);
   padding: 12px 28px;
-  border: 1px solid rgba(203, 27, 69, 0.35);
+  border: 1px solid rgba(31, 43, 61, 0.28);
 }
 
 .btn--ghost:hover,
 .btn--ghost:focus {
   border-color: var(--color-primary);
   color: var(--color-primary-dark);
-  background: rgba(203, 27, 69, 0.08);
+  background: rgba(31, 43, 61, 0.08);
 }
 
 .section-head {
@@ -220,7 +222,7 @@
   text-transform: uppercase;
   font-weight: 600;
   color: var(--color-muted);
-  background: rgba(255, 255, 255, 0.85);
+  background: rgba(246, 247, 247, 0.86);
   backdrop-filter: blur(6px);
 }
 
@@ -237,7 +239,7 @@
   background: transparent;
   padding: 0;
   letter-spacing: 0.08em;
-  color: rgba(111, 118, 129, 0.85);
+  color: rgba(31, 43, 61, 0.55);
 }
 
 @media (max-width: 1024px) {
@@ -270,7 +272,7 @@
     position: absolute;
     inset: 72px 16px auto;
     flex-direction: column;
-    background: rgba(255, 255, 255, 0.98);
+    background: rgba(250, 250, 248, 0.98);
     padding: 20px;
     border-radius: var(--radius-md);
     box-shadow: var(--shadow-soft);

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -44,7 +44,7 @@
   background: rgba(255, 255, 255, 0.92);
   backdrop-filter: blur(18px);
   border-bottom: 1px solid var(--color-border);
-  box-shadow: 0 1px 0 rgba(53, 68, 83, 0.06);
+  box-shadow: 0 1px 0 rgba(133, 104, 89, 0.12);
 }
 
 .site-header__inner {
@@ -71,7 +71,7 @@
   place-items: center;
   border-radius: 12px;
   background: var(--gradient-hero);
-  color: #2f2a26;
+  color: var(--color-ink);
   font-family: var(--font-display);
   font-size: 1.2rem;
 }
@@ -83,7 +83,7 @@
 .site-nav__toggle {
   display: none;
   background: transparent;
-  color: #2f2a26;
+  color: var(--color-ink);
   border: 1px solid var(--color-border);
   padding: 8px 16px;
   border-radius: 999px;
@@ -135,7 +135,7 @@
 
 .btn--accent {
   background: var(--color-accent);
-  color: #3f2c1d;
+  color: #6b3b2a;
   padding: 12px 28px;
 }
 
@@ -163,14 +163,14 @@
   background: transparent;
   color: var(--color-primary);
   padding: 12px 28px;
-  border: 1px solid rgba(209, 73, 91, 0.35);
+  border: 1px solid rgba(203, 27, 69, 0.35);
 }
 
 .btn--ghost:hover,
 .btn--ghost:focus {
   border-color: var(--color-primary);
   color: var(--color-primary-dark);
-  background: rgba(209, 73, 91, 0.06);
+  background: rgba(203, 27, 69, 0.08);
 }
 
 .section-head {

--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -49,7 +49,7 @@
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(120deg, rgba(6, 11, 26, 0.2), rgba(6, 11, 26, 0.78));
+  background: linear-gradient(120deg, rgba(247, 242, 235, 0.85), rgba(209, 73, 91, 0.32));
   pointer-events: none;
   z-index: 1;
 }
@@ -98,7 +98,7 @@
 }
 
 .hero-slide__text {
-  color: var(--color-muted-light);
+  color: var(--color-muted);
   margin: 0;
 }
 
@@ -127,22 +127,22 @@
   height: 14px;
   border-radius: 50%;
   border: 0;
-  background: rgba(255, 255, 255, 0.35);
+  background: rgba(47, 42, 38, 0.2);
   cursor: pointer;
   transition: transform 0.2s ease, background 0.2s ease;
 }
 
 .hero__dots button.is-active,
 .testimonial__dots button.is-active {
-  background: var(--color-accent);
+  background: var(--color-primary);
   transform: scale(1.1);
 }
 
 .partners {
   background: var(--color-section);
   padding: 28px 0;
-  border-top: 1px solid rgba(148, 163, 184, 0.12);
-  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .partner-list {
@@ -157,7 +157,7 @@
   font-weight: 600;
   letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: var(--color-muted-light);
+  color: var(--color-muted);
 }
 
 .feature-grid {
@@ -184,7 +184,7 @@
   width: 48px;
   height: 48px;
   border-radius: 14px;
-  background: var(--gradient-card);
+  background: linear-gradient(135deg, rgba(209, 73, 91, 0.18), rgba(232, 167, 93, 0.4));
 }
 
 .programs {
@@ -208,7 +208,7 @@
 
 .program-card__media {
   /* 可用 640x420px 運動課程照片直接覆蓋 background-image */
-  background: linear-gradient(135deg, rgba(255, 95, 60, 0.65), rgba(15, 23, 42, 0.9));
+  background: linear-gradient(135deg, rgba(209, 73, 91, 0.35), rgba(232, 167, 93, 0.45));
 }
 
 .program-card__body {
@@ -327,31 +327,31 @@
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(160deg, rgba(6, 11, 26, 0.05), rgba(6, 11, 26, 0.6));
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.6), rgba(209, 73, 91, 0.18));
 }
 
 .gallery__item--court {
-  background-image: linear-gradient(120deg, #ff7e5f, #1f2937);
+  background-image: linear-gradient(135deg, #f3d6c3, #f9f5ef);
 }
 
 .gallery__item--pool {
-  background-image: linear-gradient(135deg, #38bdf8, #0f172a);
+  background-image: linear-gradient(135deg, #bcdbe7, #f7f2eb);
 }
 
 .gallery__item--gym {
-  background-image: linear-gradient(135deg, #f97316, #111827);
+  background-image: linear-gradient(135deg, #f1c9c3, #f7f2eb);
 }
 
 .gallery__item--arena {
-  background-image: linear-gradient(135deg, #f43f5e, #1f2937);
+  background-image: linear-gradient(135deg, #e5b7c8, #f9f1e7);
 }
 
 .gallery__item--soccer {
-  background-image: linear-gradient(135deg, #34d399, #0f172a);
+  background-image: linear-gradient(135deg, #c8e0c0, #f7f4ee);
 }
 
 .gallery__item--lounge {
-  background-image: linear-gradient(135deg, #a855f7, #111827);
+  background-image: linear-gradient(135deg, #d8cee6, #faf6ef);
 }
 
 .plans {
@@ -395,8 +395,8 @@
 }
 
 .plan-card--featured {
-  background: linear-gradient(135deg, rgba(255, 95, 60, 0.2), rgba(17, 24, 39, 0.98));
-  border: 1px solid rgba(255, 209, 102, 0.45);
+  background: linear-gradient(135deg, rgba(209, 73, 91, 0.18), rgba(232, 167, 93, 0.35));
+  border: 1px solid rgba(209, 73, 91, 0.24);
   transform: translateY(-6px);
 }
 
@@ -432,7 +432,7 @@
   height: 96px;
   margin: 0 auto;
   border-radius: 32px;
-  background: var(--gradient-card);
+  background: linear-gradient(135deg, rgba(209, 73, 91, 0.16), rgba(232, 167, 93, 0.4));
 }
 
 .testimonials {
@@ -519,19 +519,20 @@
 }
 
 .news-card__media--league {
-  background-image: linear-gradient(135deg, #f97316, #111827);
+  background-image: linear-gradient(135deg, rgba(209, 73, 91, 0.35), rgba(232, 167, 93, 0.4));
 }
 
 .news-card__media--clinic {
-  background-image: linear-gradient(135deg, #0ea5e9, #1e293b);
+  background-image: linear-gradient(135deg, rgba(188, 219, 231, 0.4), rgba(209, 73, 91, 0.24));
 }
 
 .news-card__media--community {
-  background-image: linear-gradient(135deg, #22d3ee, #0f172a);
+  background-image: linear-gradient(135deg, rgba(200, 224, 192, 0.38), rgba(209, 73, 91, 0.22));
 }
 
 .cta {
-  background: linear-gradient(120deg, rgba(255, 95, 60, 0.65), rgba(6, 11, 26, 0.95));
+  background: linear-gradient(120deg, rgba(209, 73, 91, 0.2), rgba(232, 167, 93, 0.45));
+  color: #2f2a26;
 }
 
 .cta__inner {
@@ -564,6 +565,7 @@
   display: grid;
   gap: 20px;
   box-shadow: var(--shadow-card);
+  border: 1px solid var(--color-border);
 }
 
 .form-group {
@@ -574,12 +576,17 @@
 input,
 select,
 textarea {
-  background: rgba(15, 23, 42, 0.8);
-  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
   padding: 12px 16px;
-  color: #fff;
+  color: inherit;
   font: inherit;
+}
+
+input::placeholder,
+textarea::placeholder {
+  color: var(--color-muted-light);
 }
 
 textarea {
@@ -587,8 +594,9 @@ textarea {
 }
 
 .site-footer {
-  background: #050a1a;
-  color: var(--color-muted-light);
+  background: var(--color-card);
+  color: var(--color-muted);
+  border-top: 1px solid var(--color-border);
 }
 
 .site-footer__top {
@@ -611,7 +619,7 @@ textarea {
   font-family: var(--font-display);
   text-transform: uppercase;
   letter-spacing: 0.16em;
-  color: #fff;
+  color: #2f2a26;
 }
 
 .site-footer__newsletter form {
@@ -621,10 +629,13 @@ textarea {
 
 .site-footer__newsletter input {
   flex: 1;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid var(--color-border);
+  color: inherit;
 }
 
 .site-footer__bottom {
-  border-top: 1px solid rgba(148, 163, 184, 0.15);
+  border-top: 1px solid var(--color-border);
   padding: 20px 0;
 }
 
@@ -637,35 +648,35 @@ textarea {
 }
 
 .program-card__media--tennis {
-  background-image: linear-gradient(135deg, #38bdf8, #1f2937);
+  background-image: linear-gradient(135deg, #c4dce6, #f7f2eb);
 }
 
 .program-card__media--basketball {
-  background-image: linear-gradient(135deg, #f97316, #111827);
+  background-image: linear-gradient(135deg, #f5c8b8, #f8f2eb);
 }
 
 .program-card__media--swim {
-  background-image: linear-gradient(135deg, #22d3ee, #0f172a);
+  background-image: linear-gradient(135deg, #bcdbe7, #f7f2eb);
 }
 
 .program-card__media--fitness {
-  background-image: linear-gradient(135deg, #a855f7, #111827);
+  background-image: linear-gradient(135deg, #d8cee6, #faf6ef);
 }
 
 .coach-card__avatar--tennis {
-  background-image: linear-gradient(135deg, #38bdf8, #1f2937);
+  background-image: linear-gradient(135deg, #c4dce6, #f7f2eb);
 }
 
 .coach-card__avatar--basketball {
-  background-image: linear-gradient(135deg, #f97316, #111827);
+  background-image: linear-gradient(135deg, #f5c8b8, #f8f2eb);
 }
 
 .coach-card__avatar--swim {
-  background-image: linear-gradient(135deg, #0ea5e9, #1e293b);
+  background-image: linear-gradient(135deg, #bcdbe7, #f7f2eb);
 }
 
 .coach-card__avatar--soccer {
-  background-image: linear-gradient(135deg, #34d399, #0f172a);
+  background-image: linear-gradient(135deg, #c8e0c0, #f7f4ee);
 }
 
 @media (max-width: 1024px) {

--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -49,7 +49,7 @@
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(120deg, rgba(247, 242, 235, 0.85), rgba(209, 73, 91, 0.32));
+  background: linear-gradient(120deg, rgba(245, 242, 232, 0.88), rgba(203, 27, 69, 0.3));
   pointer-events: none;
   z-index: 1;
 }
@@ -127,7 +127,7 @@
   height: 14px;
   border-radius: 50%;
   border: 0;
-  background: rgba(47, 42, 38, 0.2);
+  background: rgba(67, 61, 60, 0.22);
   cursor: pointer;
   transition: transform 0.2s ease, background 0.2s ease;
 }
@@ -184,7 +184,7 @@
   width: 48px;
   height: 48px;
   border-radius: 14px;
-  background: linear-gradient(135deg, rgba(209, 73, 91, 0.18), rgba(232, 167, 93, 0.4));
+  background: linear-gradient(135deg, rgba(203, 27, 69, 0.2), rgba(248, 181, 0, 0.35));
 }
 
 .programs {
@@ -208,7 +208,7 @@
 
 .program-card__media {
   /* 可用 640x420px 運動課程照片直接覆蓋 background-image */
-  background: linear-gradient(135deg, rgba(209, 73, 91, 0.35), rgba(232, 167, 93, 0.45));
+  background: linear-gradient(135deg, rgba(203, 27, 69, 0.32), rgba(248, 181, 0, 0.42));
 }
 
 .program-card__body {
@@ -327,31 +327,31 @@
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(160deg, rgba(255, 255, 255, 0.6), rgba(209, 73, 91, 0.18));
+  background: linear-gradient(160deg, rgba(252, 250, 242, 0.68), rgba(203, 27, 69, 0.18));
 }
 
 .gallery__item--court {
-  background-image: linear-gradient(135deg, #f3d6c3, #f9f5ef);
+  background-image: linear-gradient(135deg, #dcd3b2, #fcfaf2);
 }
 
 .gallery__item--pool {
-  background-image: linear-gradient(135deg, #bcdbe7, #f7f2eb);
+  background-image: linear-gradient(135deg, #7db9de, #fcfaf2);
 }
 
 .gallery__item--gym {
-  background-image: linear-gradient(135deg, #f1c9c3, #f7f2eb);
+  background-image: linear-gradient(135deg, #e16b8c, #fedfe1);
 }
 
 .gallery__item--arena {
-  background-image: linear-gradient(135deg, #e5b7c8, #f9f1e7);
+  background-image: linear-gradient(135deg, #f596aa, #fedfe1);
 }
 
 .gallery__item--soccer {
-  background-image: linear-gradient(135deg, #c8e0c0, #f7f4ee);
+  background-image: linear-gradient(135deg, #a8d8b9, #fcfaf2);
 }
 
 .gallery__item--lounge {
-  background-image: linear-gradient(135deg, #d8cee6, #faf6ef);
+  background-image: linear-gradient(135deg, #a69abd, #fcfaf2);
 }
 
 .plans {
@@ -395,8 +395,8 @@
 }
 
 .plan-card--featured {
-  background: linear-gradient(135deg, rgba(209, 73, 91, 0.18), rgba(232, 167, 93, 0.35));
-  border: 1px solid rgba(209, 73, 91, 0.24);
+  background: linear-gradient(135deg, rgba(203, 27, 69, 0.2), rgba(248, 181, 0, 0.32));
+  border: 1px solid rgba(203, 27, 69, 0.26);
   transform: translateY(-6px);
 }
 
@@ -432,7 +432,7 @@
   height: 96px;
   margin: 0 auto;
   border-radius: 32px;
-  background: linear-gradient(135deg, rgba(209, 73, 91, 0.16), rgba(232, 167, 93, 0.4));
+  background: linear-gradient(135deg, rgba(203, 27, 69, 0.18), rgba(248, 181, 0, 0.38));
 }
 
 .testimonials {
@@ -519,20 +519,20 @@
 }
 
 .news-card__media--league {
-  background-image: linear-gradient(135deg, rgba(209, 73, 91, 0.35), rgba(232, 167, 93, 0.4));
+  background-image: linear-gradient(135deg, rgba(203, 27, 69, 0.32), rgba(248, 181, 0, 0.4));
 }
 
 .news-card__media--clinic {
-  background-image: linear-gradient(135deg, rgba(188, 219, 231, 0.4), rgba(209, 73, 91, 0.24));
+  background-image: linear-gradient(135deg, rgba(125, 185, 222, 0.45), rgba(203, 27, 69, 0.24));
 }
 
 .news-card__media--community {
-  background-image: linear-gradient(135deg, rgba(200, 224, 192, 0.38), rgba(209, 73, 91, 0.22));
+  background-image: linear-gradient(135deg, rgba(168, 216, 185, 0.42), rgba(203, 27, 69, 0.22));
 }
 
 .cta {
-  background: linear-gradient(120deg, rgba(209, 73, 91, 0.2), rgba(232, 167, 93, 0.45));
-  color: #2f2a26;
+  background: linear-gradient(120deg, rgba(203, 27, 69, 0.24), rgba(248, 181, 0, 0.42));
+  color: var(--color-ink);
 }
 
 .cta__inner {
@@ -619,7 +619,7 @@ textarea {
   font-family: var(--font-display);
   text-transform: uppercase;
   letter-spacing: 0.16em;
-  color: #2f2a26;
+  color: var(--color-ink);
 }
 
 .site-footer__newsletter form {
@@ -648,35 +648,35 @@ textarea {
 }
 
 .program-card__media--tennis {
-  background-image: linear-gradient(135deg, #c4dce6, #f7f2eb);
+  background-image: linear-gradient(135deg, #a8d8b9, #fcfaf2);
 }
 
 .program-card__media--basketball {
-  background-image: linear-gradient(135deg, #f5c8b8, #f8f2eb);
+  background-image: linear-gradient(135deg, #e16b8c, #fedfe1);
 }
 
 .program-card__media--swim {
-  background-image: linear-gradient(135deg, #bcdbe7, #f7f2eb);
+  background-image: linear-gradient(135deg, #7db9de, #fcfaf2);
 }
 
 .program-card__media--fitness {
-  background-image: linear-gradient(135deg, #d8cee6, #faf6ef);
+  background-image: linear-gradient(135deg, #a69abd, #fcfaf2);
 }
 
 .coach-card__avatar--tennis {
-  background-image: linear-gradient(135deg, #c4dce6, #f7f2eb);
+  background-image: linear-gradient(135deg, #a8d8b9, #fcfaf2);
 }
 
 .coach-card__avatar--basketball {
-  background-image: linear-gradient(135deg, #f5c8b8, #f8f2eb);
+  background-image: linear-gradient(135deg, #e16b8c, #fedfe1);
 }
 
 .coach-card__avatar--swim {
-  background-image: linear-gradient(135deg, #bcdbe7, #f7f2eb);
+  background-image: linear-gradient(135deg, #7db9de, #fcfaf2);
 }
 
 .coach-card__avatar--soccer {
-  background-image: linear-gradient(135deg, #c8e0c0, #f7f4ee);
+  background-image: linear-gradient(135deg, #7ba23f, #fcfaf2);
 }
 
 @media (max-width: 1024px) {

--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -49,7 +49,7 @@
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(120deg, rgba(245, 242, 232, 0.88), rgba(203, 27, 69, 0.3));
+  background: linear-gradient(120deg, rgba(24, 34, 50, 0.82), rgba(196, 160, 82, 0.3));
   pointer-events: none;
   z-index: 1;
 }
@@ -127,7 +127,7 @@
   height: 14px;
   border-radius: 50%;
   border: 0;
-  background: rgba(67, 61, 60, 0.22);
+  background: rgba(28, 36, 48, 0.28);
   cursor: pointer;
   transition: transform 0.2s ease, background 0.2s ease;
 }
@@ -184,7 +184,7 @@
   width: 48px;
   height: 48px;
   border-radius: 14px;
-  background: linear-gradient(135deg, rgba(203, 27, 69, 0.2), rgba(248, 181, 0, 0.35));
+  background: linear-gradient(135deg, rgba(31, 43, 61, 0.2), rgba(196, 160, 82, 0.3));
 }
 
 .programs {
@@ -208,7 +208,7 @@
 
 .program-card__media {
   /* 可用 640x420px 運動課程照片直接覆蓋 background-image */
-  background: linear-gradient(135deg, rgba(203, 27, 69, 0.32), rgba(248, 181, 0, 0.42));
+  background: linear-gradient(135deg, rgba(31, 43, 61, 0.32), rgba(196, 160, 82, 0.4));
 }
 
 .program-card__body {
@@ -327,31 +327,31 @@
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(160deg, rgba(252, 250, 242, 0.68), rgba(203, 27, 69, 0.18));
+  background: linear-gradient(160deg, rgba(245, 246, 244, 0.65), rgba(31, 43, 61, 0.26));
 }
 
 .gallery__item--court {
-  background-image: linear-gradient(135deg, #dcd3b2, #fcfaf2);
+  background-image: linear-gradient(135deg, #28374c, #192434);
 }
 
 .gallery__item--pool {
-  background-image: linear-gradient(135deg, #7db9de, #fcfaf2);
+  background-image: linear-gradient(135deg, #1f3c4a, #11232d);
 }
 
 .gallery__item--gym {
-  background-image: linear-gradient(135deg, #e16b8c, #fedfe1);
+  background-image: linear-gradient(135deg, #312936, #1a1521);
 }
 
 .gallery__item--arena {
-  background-image: linear-gradient(135deg, #f596aa, #fedfe1);
+  background-image: linear-gradient(135deg, #2c3748, #151d2a);
 }
 
 .gallery__item--soccer {
-  background-image: linear-gradient(135deg, #a8d8b9, #fcfaf2);
+  background-image: linear-gradient(135deg, #23362d, #101c16);
 }
 
 .gallery__item--lounge {
-  background-image: linear-gradient(135deg, #a69abd, #fcfaf2);
+  background-image: linear-gradient(135deg, #2c3240, #161b25);
 }
 
 .plans {
@@ -395,8 +395,8 @@
 }
 
 .plan-card--featured {
-  background: linear-gradient(135deg, rgba(203, 27, 69, 0.2), rgba(248, 181, 0, 0.32));
-  border: 1px solid rgba(203, 27, 69, 0.26);
+  background: linear-gradient(135deg, rgba(31, 43, 61, 0.22), rgba(196, 160, 82, 0.36));
+  border: 1px solid rgba(31, 43, 61, 0.18);
   transform: translateY(-6px);
 }
 
@@ -432,7 +432,7 @@
   height: 96px;
   margin: 0 auto;
   border-radius: 32px;
-  background: linear-gradient(135deg, rgba(203, 27, 69, 0.18), rgba(248, 181, 0, 0.38));
+  background: linear-gradient(135deg, rgba(31, 43, 61, 0.26), rgba(196, 160, 82, 0.4));
 }
 
 .testimonials {
@@ -519,20 +519,20 @@
 }
 
 .news-card__media--league {
-  background-image: linear-gradient(135deg, rgba(203, 27, 69, 0.32), rgba(248, 181, 0, 0.4));
+  background-image: linear-gradient(135deg, rgba(31, 43, 61, 0.32), rgba(196, 160, 82, 0.4));
 }
 
 .news-card__media--clinic {
-  background-image: linear-gradient(135deg, rgba(125, 185, 222, 0.45), rgba(203, 27, 69, 0.24));
+  background-image: linear-gradient(135deg, rgba(46, 74, 94, 0.42), rgba(143, 153, 168, 0.36));
 }
 
 .news-card__media--community {
-  background-image: linear-gradient(135deg, rgba(168, 216, 185, 0.42), rgba(203, 27, 69, 0.22));
+  background-image: linear-gradient(135deg, rgba(40, 65, 56, 0.4), rgba(196, 160, 82, 0.3));
 }
 
 .cta {
-  background: linear-gradient(120deg, rgba(203, 27, 69, 0.24), rgba(248, 181, 0, 0.42));
-  color: var(--color-ink);
+  background: linear-gradient(120deg, rgba(20, 31, 49, 0.92), rgba(196, 160, 82, 0.42));
+  color: #f7f6f2;
 }
 
 .cta__inner {
@@ -648,35 +648,35 @@ textarea {
 }
 
 .program-card__media--tennis {
-  background-image: linear-gradient(135deg, #a8d8b9, #fcfaf2);
+  background-image: linear-gradient(135deg, #28374c, #172233);
 }
 
 .program-card__media--basketball {
-  background-image: linear-gradient(135deg, #e16b8c, #fedfe1);
+  background-image: linear-gradient(135deg, #322836, #1a1522);
 }
 
 .program-card__media--swim {
-  background-image: linear-gradient(135deg, #7db9de, #fcfaf2);
+  background-image: linear-gradient(135deg, #1e3a49, #10232d);
 }
 
 .program-card__media--fitness {
-  background-image: linear-gradient(135deg, #a69abd, #fcfaf2);
+  background-image: linear-gradient(135deg, #2d333f, #161b25);
 }
 
 .coach-card__avatar--tennis {
-  background-image: linear-gradient(135deg, #a8d8b9, #fcfaf2);
+  background-image: linear-gradient(135deg, #2a3b4e, #182434);
 }
 
 .coach-card__avatar--basketball {
-  background-image: linear-gradient(135deg, #e16b8c, #fedfe1);
+  background-image: linear-gradient(135deg, #342836, #1a1422);
 }
 
 .coach-card__avatar--swim {
-  background-image: linear-gradient(135deg, #7db9de, #fcfaf2);
+  background-image: linear-gradient(135deg, #1f3b4a, #112430);
 }
 
 .coach-card__avatar--soccer {
-  background-image: linear-gradient(135deg, #7ba23f, #fcfaf2);
+  background-image: linear-gradient(135deg, #22352c, #101b16);
 }
 
 @media (max-width: 1024px) {

--- a/assets/css/shop.css
+++ b/assets/css/shop.css
@@ -13,12 +13,12 @@ body {
 }
 
 .site-header--plain {
-  background: rgba(255, 255, 255, 0.92);
+  background: rgba(255, 255, 255, 0.9);
   border-bottom: 1px solid var(--color-border);
   position: sticky;
   top: 0;
   z-index: 50;
-  box-shadow: 0 1px 0 rgba(133, 104, 89, 0.12);
+  box-shadow: 0 1px 0 rgba(20, 31, 49, 0.1);
 }
 
 .hero.hero--shop {
@@ -72,7 +72,7 @@ body {
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(120deg, rgba(245, 242, 232, 0.88), rgba(203, 27, 69, 0.3));
+  background: linear-gradient(120deg, rgba(24, 34, 50, 0.82), rgba(196, 160, 82, 0.32));
   pointer-events: none;
   z-index: 1;
 }
@@ -148,7 +148,7 @@ body {
   height: 14px;
   border-radius: 50%;
   border: 0;
-  background: rgba(67, 61, 60, 0.22);
+  background: rgba(28, 36, 48, 0.28);
   cursor: pointer;
   transition: transform 0.2s ease, background 0.2s ease;
 }
@@ -205,19 +205,19 @@ body {
 }
 
 .category-card__media--racket {
-  background-image: linear-gradient(135deg, #7db9de, #fcfaf2);
+  background-image: linear-gradient(135deg, #28374c, #172233);
 }
 
 .category-card__media--shoe {
-  background-image: linear-gradient(135deg, #e16b8c, #fedfe1);
+  background-image: linear-gradient(135deg, #312936, #1a1521);
 }
 
 .category-card__media--apparel {
-  background-image: linear-gradient(135deg, #a69abd, #fcfaf2);
+  background-image: linear-gradient(135deg, #2d333f, #161b25);
 }
 
 .category-card__media--gear {
-  background-image: linear-gradient(135deg, #a8d8b9, #fcfaf2);
+  background-image: linear-gradient(135deg, #23362d, #101b16);
 }
 
 .category-card__body {
@@ -301,7 +301,7 @@ body {
   justify-content: center;
   align-items: center;
   padding: clamp(18px, 2vw, 24px);
-  background: rgba(203, 27, 69, 0.12);
+  background: rgba(31, 43, 61, 0.12);
   min-height: 220px;
 }
 
@@ -348,7 +348,7 @@ body {
 .bundle-card__media {
   position: relative;
   margin: 0;
-  background: rgba(203, 27, 69, 0.12);
+  background: rgba(31, 43, 61, 0.12);
   overflow: hidden;
   display: flex;
   align-items: center;
@@ -440,11 +440,11 @@ body {
 }
 
 .promo-card--orange {
-  background: linear-gradient(135deg, rgba(203, 27, 69, 0.24), rgba(248, 181, 0, 0.4));
+  background: linear-gradient(135deg, rgba(31, 43, 61, 0.22), rgba(196, 160, 82, 0.4));
 }
 
 .promo-card--blue {
-  background: linear-gradient(135deg, rgba(125, 185, 222, 0.45), rgba(203, 27, 69, 0.2));
+  background: linear-gradient(135deg, rgba(46, 74, 94, 0.4), rgba(143, 153, 168, 0.28));
 }
 
 .brands {
@@ -482,7 +482,7 @@ body {
   position: relative;
   min-height: 320px;
   border-radius: var(--radius-lg);
-  background-image: linear-gradient(135deg, #a69abd, #fcfaf2);
+  background-image: linear-gradient(135deg, #2d3c4f, #161f2b);
   box-shadow: var(--shadow-card);
   overflow: hidden;
 }
@@ -505,8 +505,8 @@ body {
 }
 
 .newsletter {
-  background: linear-gradient(120deg, rgba(203, 27, 69, 0.22), rgba(248, 181, 0, 0.4));
-  color: var(--color-ink);
+  background: linear-gradient(120deg, rgba(20, 31, 49, 0.9), rgba(196, 160, 82, 0.4));
+  color: #f7f6f2;
 }
 
 .newsletter__inner {

--- a/assets/css/shop.css
+++ b/assets/css/shop.css
@@ -1,6 +1,6 @@
 body {
   background: var(--color-background);
-  color: #2f2a26;
+  color: var(--color-ink);
 }
 
 .page-shop section {
@@ -18,7 +18,7 @@ body {
   position: sticky;
   top: 0;
   z-index: 50;
-  box-shadow: 0 1px 0 rgba(53, 68, 83, 0.06);
+  box-shadow: 0 1px 0 rgba(133, 104, 89, 0.12);
 }
 
 .hero.hero--shop {
@@ -72,7 +72,7 @@ body {
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(120deg, rgba(247, 242, 235, 0.85), rgba(209, 73, 91, 0.32));
+  background: linear-gradient(120deg, rgba(245, 242, 232, 0.88), rgba(203, 27, 69, 0.3));
   pointer-events: none;
   z-index: 1;
 }
@@ -116,7 +116,7 @@ body {
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-soft);
   border: 1px solid var(--color-border);
-  color: #2f2a26;
+  color: var(--color-ink);
 }
 
 .hero--shop .hero-slide__content h1,
@@ -148,7 +148,7 @@ body {
   height: 14px;
   border-radius: 50%;
   border: 0;
-  background: rgba(47, 42, 38, 0.2);
+  background: rgba(67, 61, 60, 0.22);
   cursor: pointer;
   transition: transform 0.2s ease, background 0.2s ease;
 }
@@ -205,19 +205,19 @@ body {
 }
 
 .category-card__media--racket {
-  background-image: linear-gradient(135deg, #c4dce6, #f7f2eb);
+  background-image: linear-gradient(135deg, #7db9de, #fcfaf2);
 }
 
 .category-card__media--shoe {
-  background-image: linear-gradient(135deg, #f5c8b8, #f8f2eb);
+  background-image: linear-gradient(135deg, #e16b8c, #fedfe1);
 }
 
 .category-card__media--apparel {
-  background-image: linear-gradient(135deg, #d8cee6, #faf6ef);
+  background-image: linear-gradient(135deg, #a69abd, #fcfaf2);
 }
 
 .category-card__media--gear {
-  background-image: linear-gradient(135deg, #c8e0c0, #f7f4ee);
+  background-image: linear-gradient(135deg, #a8d8b9, #fcfaf2);
 }
 
 .category-card__body {
@@ -301,7 +301,7 @@ body {
   justify-content: center;
   align-items: center;
   padding: clamp(18px, 2vw, 24px);
-  background: rgba(209, 73, 91, 0.12);
+  background: rgba(203, 27, 69, 0.12);
   min-height: 220px;
 }
 
@@ -348,7 +348,7 @@ body {
 .bundle-card__media {
   position: relative;
   margin: 0;
-  background: rgba(209, 73, 91, 0.12);
+  background: rgba(203, 27, 69, 0.12);
   overflow: hidden;
   display: flex;
   align-items: center;
@@ -440,11 +440,11 @@ body {
 }
 
 .promo-card--orange {
-  background: linear-gradient(135deg, rgba(209, 73, 91, 0.2), rgba(232, 167, 93, 0.4));
+  background: linear-gradient(135deg, rgba(203, 27, 69, 0.24), rgba(248, 181, 0, 0.4));
 }
 
 .promo-card--blue {
-  background: linear-gradient(135deg, rgba(188, 219, 231, 0.4), rgba(209, 73, 91, 0.18));
+  background: linear-gradient(135deg, rgba(125, 185, 222, 0.45), rgba(203, 27, 69, 0.2));
 }
 
 .brands {
@@ -482,7 +482,7 @@ body {
   position: relative;
   min-height: 320px;
   border-radius: var(--radius-lg);
-  background-image: linear-gradient(135deg, #d8cee6, #faf6ef);
+  background-image: linear-gradient(135deg, #a69abd, #fcfaf2);
   box-shadow: var(--shadow-card);
   overflow: hidden;
 }
@@ -505,8 +505,8 @@ body {
 }
 
 .newsletter {
-  background: linear-gradient(120deg, rgba(209, 73, 91, 0.18), rgba(232, 167, 93, 0.4));
-  color: #2f2a26;
+  background: linear-gradient(120deg, rgba(203, 27, 69, 0.22), rgba(248, 181, 0, 0.4));
+  color: var(--color-ink);
 }
 
 .newsletter__inner {

--- a/assets/css/shop.css
+++ b/assets/css/shop.css
@@ -1,6 +1,6 @@
 body {
   background: var(--color-background);
-  color: #f8fafc;
+  color: #2f2a26;
 }
 
 .page-shop section {
@@ -13,11 +13,12 @@ body {
 }
 
 .site-header--plain {
-  background: rgba(6, 11, 26, 0.92);
-  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(255, 255, 255, 0.92);
+  border-bottom: 1px solid var(--color-border);
   position: sticky;
   top: 0;
   z-index: 50;
+  box-shadow: 0 1px 0 rgba(53, 68, 83, 0.06);
 }
 
 .hero.hero--shop {
@@ -71,7 +72,7 @@ body {
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(120deg, rgba(6, 11, 26, 0.2), rgba(6, 11, 26, 0.78));
+  background: linear-gradient(120deg, rgba(247, 242, 235, 0.85), rgba(209, 73, 91, 0.32));
   pointer-events: none;
   z-index: 1;
 }
@@ -110,10 +111,12 @@ body {
   align-items: center;
   text-align: center;
   gap: 18px;
-  background: rgba(6, 11, 26, 0.78);
+  background: rgba(255, 255, 255, 0.9);
   padding: 32px 36px;
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-soft);
+  border: 1px solid var(--color-border);
+  color: #2f2a26;
 }
 
 .hero--shop .hero-slide__content h1,
@@ -122,7 +125,7 @@ body {
 }
 
 .hero--shop .hero-slide__content p {
-  color: var(--color-muted-light);
+  color: var(--color-muted);
 }
 
 .hero--shop .hero-slide__actions {
@@ -145,13 +148,13 @@ body {
   height: 14px;
   border-radius: 50%;
   border: 0;
-  background: rgba(255, 255, 255, 0.32);
+  background: rgba(47, 42, 38, 0.2);
   cursor: pointer;
   transition: transform 0.2s ease, background 0.2s ease;
 }
 
 .hero--shop .hero__dots button.is-active {
-  background: var(--color-accent);
+  background: var(--color-primary);
   transform: scale(1.1);
 }
 
@@ -202,19 +205,19 @@ body {
 }
 
 .category-card__media--racket {
-  background-image: linear-gradient(135deg, #0ea5e9, #1e293b);
+  background-image: linear-gradient(135deg, #c4dce6, #f7f2eb);
 }
 
 .category-card__media--shoe {
-  background-image: linear-gradient(135deg, #f97316, #111827);
+  background-image: linear-gradient(135deg, #f5c8b8, #f8f2eb);
 }
 
 .category-card__media--apparel {
-  background-image: linear-gradient(135deg, #a855f7, #0f172a);
+  background-image: linear-gradient(135deg, #d8cee6, #faf6ef);
 }
 
 .category-card__media--gear {
-  background-image: linear-gradient(135deg, #22d3ee, #0f172a);
+  background-image: linear-gradient(135deg, #c8e0c0, #f7f4ee);
 }
 
 .category-card__body {
@@ -298,7 +301,7 @@ body {
   justify-content: center;
   align-items: center;
   padding: clamp(18px, 2vw, 24px);
-  background: rgba(15, 23, 42, 0.5);
+  background: rgba(209, 73, 91, 0.12);
   min-height: 220px;
 }
 
@@ -329,7 +332,7 @@ body {
 .product-card__price {
   font-family: var(--font-display);
   font-size: 1.3rem;
-  color: #fcd34d;
+  color: var(--color-primary);
 }
 
 .bundle-card {
@@ -345,7 +348,7 @@ body {
 .bundle-card__media {
   position: relative;
   margin: 0;
-  background: rgba(15, 23, 42, 0.4);
+  background: rgba(209, 73, 91, 0.12);
   overflow: hidden;
   display: flex;
   align-items: center;
@@ -380,8 +383,8 @@ body {
 .bundle-card__includes {
   padding: clamp(18px, 2vw, 24px);
   border-radius: var(--radius-md);
-  background: rgba(15, 23, 42, 0.55);
-  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid var(--color-border);
   display: grid;
   gap: 12px;
 }
@@ -391,7 +394,7 @@ body {
   font-size: 1rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: rgba(226, 232, 240, 0.86);
+  color: var(--color-primary);
 }
 
 .bundle-card__list {
@@ -415,7 +418,7 @@ body {
 .bundle-card__price {
   font-family: var(--font-display);
   font-size: 2rem;
-  color: #fcd34d;
+  color: var(--color-primary);
 }
 
 .promos {
@@ -437,11 +440,11 @@ body {
 }
 
 .promo-card--orange {
-  background: linear-gradient(135deg, rgba(249, 115, 22, 0.75), rgba(15, 23, 42, 0.9));
+  background: linear-gradient(135deg, rgba(209, 73, 91, 0.2), rgba(232, 167, 93, 0.4));
 }
 
 .promo-card--blue {
-  background: linear-gradient(135deg, rgba(14, 165, 233, 0.75), rgba(15, 23, 42, 0.9));
+  background: linear-gradient(135deg, rgba(188, 219, 231, 0.4), rgba(209, 73, 91, 0.18));
 }
 
 .brands {
@@ -460,7 +463,7 @@ body {
   font-family: var(--font-display);
   letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: var(--color-muted-light);
+  color: var(--color-muted);
 }
 
 .service {
@@ -479,7 +482,7 @@ body {
   position: relative;
   min-height: 320px;
   border-radius: var(--radius-lg);
-  background-image: linear-gradient(135deg, #a855f7, #0f172a);
+  background-image: linear-gradient(135deg, #d8cee6, #faf6ef);
   box-shadow: var(--shadow-card);
   overflow: hidden;
 }
@@ -502,7 +505,8 @@ body {
 }
 
 .newsletter {
-  background: linear-gradient(120deg, rgba(255, 95, 60, 0.5), rgba(6, 11, 26, 0.9));
+  background: linear-gradient(120deg, rgba(209, 73, 91, 0.18), rgba(232, 167, 93, 0.4));
+  color: #2f2a26;
 }
 
 .newsletter__inner {
@@ -524,11 +528,16 @@ body {
 
 .newsletter__form input {
   flex: 1;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid var(--color-border);
+  color: inherit;
 }
 
 .site-footer {
-  background: #050a1a;
+  background: var(--color-card);
   padding: 32px 0;
+  border-top: 1px solid var(--color-border);
+  color: var(--color-muted);
 }
 
 @media (min-width: 720px) {


### PR DESCRIPTION
## Summary
- update global color tokens, shadows, and buttons to a warm minimalist palette
- refresh shared components, forms, and footers for the new light presentation
- restyle home, about, and shop section gradients to match the Japanese-inspired aesthetic

## Testing
- Manual visual check in browser (index.html)


------
https://chatgpt.com/codex/tasks/task_e_68e0bd08236c832cae29182d8b690589