### PR TITLE
Add member registration and dashboard experience

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>關於動能運動俱樂部｜運動願景與團隊</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700;800&family=Rajdhani:wght@500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/base.css" />
+    <link rel="stylesheet" href="assets/css/components.css" />
+    <link rel="stylesheet" href="assets/css/about.css" />
+  </head>
+  <body>
+    <a class="skip-link" href="#main">跳至主要內容</a>
+
+    <header class="site-header site-header--plain" aria-label="主要導覽">
+      <div class="wrapper site-header__inner">
+        <a class="brand" href="index.html">
+          <span class="brand__mark">MC</span>
+          <span class="brand__text">動能運動俱樂部</span>
+        </a>
+        <nav class="site-nav" aria-label="主選單">
+          <button class="site-nav__toggle" aria-expanded="false" aria-controls="primary-nav">選單</button>
+          <ul id="primary-nav" class="site-nav__list">
+            <li><a href="index.html">首頁</a></li>
+            <li><a href="about.html" aria-current="page">關於我們</a></li>
+            <li><a href="shop.html">商店</a></li>
+            <li><a href="index.html#programs">訓練課程</a></li>
+            <li><a href="index.html#memberships">會員方案</a></li>
+            <li><a href="index.html#contact">聯絡我們</a></li>
+            <li class="nav-auth nav-auth--guest" data-auth="guest"><a href="login.html">會員登入</a></li>
+            <li class="nav-auth nav-auth--guest" data-auth="guest"><a href="register.html">加入會員</a></li>
+            <li class="nav-auth nav-auth--member" data-auth="member" hidden><a href="member-home.html">會員中心</a></li>
+            <li class="nav-auth nav-auth--member" data-auth="member" hidden>
+              <a class="nav-logout" href="#" data-action="logout">登出</a>
+            </li>
+          </ul>
+        </nav>
+        <a
+          class="btn btn--accent"
+          href="index.html#memberships"
+          data-auth-cta
+          data-guest-text="立即加入"
+          data-guest-href="index.html#memberships"
+          data-member-text="會員中心"
+          data-member-href="member-home.html"
+        >
+          立即加入
+        </a>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="page-hero" aria-label="關於我們主視覺">
+        <div class="page-hero__media">
+          <img src="assets/images/hero-2-placeholder.svg" alt="團隊合作的運動選手在場上擊掌鼓勵" />
+        </div>
+        <div class="wrapper page-hero__content">
+          <span class="eyebrow">關於動能</span>
+          <h1>打造多運動項目的策略基地</h1>
+          <p>
+            我們相信運動不只是競技，更是讓城市充滿活力的生活方式。動能運動俱樂部結合頂尖教練、國際級設施與科技化分析，陪伴每位會員在多元項目中找到專屬舞台。
+          </p>
+        </div>
+      </section>
+
+      <section class="mission" aria-label="使命與願景">
+        <div class="wrapper mission__inner">
+          <article class="mission__card">
+            <span class="eyebrow">品牌使命</span>
+            <h2>以運動連結城市，啟動全民動能</h2>
+            <p>
+              從青少年培訓到成人進階課程，我們透過跨項訓練與社群活動串起熱愛運動的靈魂，打造彼此支持的運動社群。
+            </p>
+          </article>
+          <article class="mission__card">
+            <span class="eyebrow">願景藍圖</span>
+            <h2>成為亞洲指標級多運動俱樂部</h2>
+            <p>
+              我們持續引進國際賽事規格、智慧化訓練科技與專業醫療資源，期望打造兼具競技、娛樂與教育功能的運動生態圈。
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section class="values" aria-label="核心價值">
+        <div class="wrapper">
+          <div class="section-head section-head--center">
+            <span class="eyebrow">核心價值</span>
+            <h2 class="section-title">支持每位運動者的四大承諾</h2>
+          </div>
+          <div class="values__grid">
+            <article class="value-card">
+              <h3>專業</h3>
+              <p>教練與團隊成員皆具國際證照與競賽經驗，以科學化訓練陪你前進。</p>
+            </article>
+            <article class="value-card">
+              <h3>安全</h3>
+              <p>完善的防護、恢復與醫療合作網絡，確保每次訓練都在最佳狀態下進行。</p>
+            </article>
+            <article class="value-card">
+              <h3>創新</h3>
+              <p>導入智慧穿戴、動作捕捉與資料分析，讓進步數據化、成果看得見。</p>
+            </article>
+            <article class="value-card">
+              <h3>社群</h3>
+              <p>透過聯賽、講座與公益活動，串起不同項目的運動者，共同成長。</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="timeline" aria-label="發展里程碑">
+        <div class="wrapper timeline__inner">
+          <div class="section-head">
+            <span class="eyebrow">發展里程碑</span>
+            <h2 class="section-title">一步步擴張多元運動版圖</h2>
+          </div>
+          <ol class="timeline__list">
+            <li>
+              <span class="timeline__year">2015</span>
+              <div>
+                <h3>創立第一座綜合運動中心</h3>
+                <p>以網球與籃球為核心項目，建立雙主場的訓練與競賽空間。</p>
+              </div>
+            </li>
+            <li>
+              <span class="timeline__year">2018</span>
+              <div>
+                <h3>擴增水上與體能基地</h3>
+                <p>開幕 50 公尺室內泳池與體能實驗室，導入恢復與醫療團隊。</p>
+              </div>
+            </li>
+            <li>
+              <span class="timeline__year">2021</span>
+              <div>
+                <h3>啟動智能訓練系統</h3>
+                <p>引入數據分析平台與智慧穿戴，實現跨項目共用訓練模組。</p>
+              </div>
+            </li>
+            <li>
+              <span class="timeline__year">2024</span>
+              <div>
+                <h3>跨國聯盟與公益計畫</h3>
+                <p>與亞洲各大城市合作推動青少年體育與全民運動推廣。</p>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </section>
+
+      <section class="team" aria-label="管理與教練團隊">
+        <div class="wrapper">
+          <div class="section-head section-head--center">
+            <span class="eyebrow">團隊陣容</span>
+            <h2 class="section-title">結合管理與教練的黃金陣容</h2>
+          </div>
+          <div class="team__grid">
+            <article class="team-card">
+              <div class="team-card__avatar team-card__avatar--lead" aria-hidden="true"></div>
+              <h3>葉家豪｜執行長</h3>
+              <p>曾任多家運動品牌策略長，擅長整合賽事與商業資源。</p>
+            </article>
+            <article class="team-card">
+              <div class="team-card__avatar team-card__avatar--coach" aria-hidden="true"></div>
+              <h3>林芷涵｜技術總監</h3>
+              <p>前網球國手，負責跨項訓練與教練培訓制度建立。</p>
+            </article>
+            <article class="team-card">
+              <div class="team-card__avatar team-card__avatar--performance" aria-hidden="true"></div>
+              <h3>王柏翰｜體能總監</h3>
+              <p>專精運動科學與恢復策略，打造全方位體能計畫。</p>
+            </article>
+            <article class="team-card">
+              <div class="team-card__avatar team-card__avatar--community" aria-hidden="true"></div>
+              <h3>陳韻如｜社群總監</h3>
+              <p>負責會員體驗與公益專案，讓運動熱情延伸至城市每個角落。</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="cta" aria-label="加入我們">
+        <div class="wrapper cta__inner">
+          <div class="cta__copy">
+            <h2>與我們一起開拓運動新篇章</h2>
+            <p>立即預約場館導覽或與顧問聯繫，了解如何為你的運動旅程注入全新動能。</p>
+          </div>
+          <a class="btn btn--accent" href="index.html#contact">預約導覽</a>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer" aria-label="頁尾">
+      <div class="wrapper site-footer__bottom-inner">
+        <span>© 2024 動能運動俱樂部 Motion Club. All rights reserved.</span>
+        <ul class="social-list">
+          <li><a href="#">Facebook</a></li>
+          <li><a href="#">Instagram</a></li>
+          <li><a href="#">YouTube</a></li>
+        </ul>
+      </div>
+    </footer>
+
+    <script src="assets/js/global.js" defer></script>
+  </body>
+</html>

--- a/assets/css/about.css
+++ b/assets/css/about.css
@@ -1,0 +1,210 @@
+body {
+  background: var(--color-background);
+  color: #f8fafc;
+}
+
+.site-header--plain {
+  background: rgba(6, 11, 26, 0.92);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  position: sticky;
+  top: 0;
+  z-index: 50;
+}
+
+.page-hero {
+  position: relative;
+  display: flex;
+  align-items: center;
+  padding: clamp(96px, 18vh, 160px) 0;
+  min-height: clamp(480px, 68vh, 640px);
+  background: var(--color-section);
+  overflow: hidden;
+}
+
+.page-hero__media {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+
+.page-hero__media::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(6, 11, 26, 0.25), rgba(6, 11, 26, 0.82));
+}
+
+.page-hero__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.page-hero__content {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 18px;
+  max-width: 720px;
+}
+
+.page-hero h1 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(2.8rem, 2.2rem + 2vw, 3.6rem);
+}
+
+.page-hero p {
+  color: var(--color-muted-light);
+}
+
+.mission {
+  background: var(--color-background);
+}
+
+.mission__inner {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 24px;
+}
+
+.mission__card {
+  background: var(--color-card);
+  border-radius: var(--radius-lg);
+  padding: 40px;
+  display: grid;
+  gap: 16px;
+  box-shadow: var(--shadow-card);
+}
+
+.values {
+  background: var(--color-section);
+}
+
+.values__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.value-card {
+  background: var(--color-card);
+  border-radius: var(--radius-md);
+  padding: 32px;
+  display: grid;
+  gap: 12px;
+  text-align: center;
+  box-shadow: var(--shadow-card);
+}
+
+.timeline {
+  background: var(--color-background);
+}
+
+.timeline__inner {
+  display: grid;
+  gap: 32px;
+}
+
+.timeline__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 16px;
+}
+
+.timeline__list li {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 24px;
+  align-items: start;
+  background: var(--color-card);
+  border-radius: var(--radius-md);
+  padding: 24px 28px;
+  box-shadow: var(--shadow-card);
+}
+
+.timeline__year {
+  font-family: var(--font-display);
+  font-size: 2.2rem;
+  color: var(--color-accent);
+}
+
+.team {
+  background: var(--color-section);
+}
+
+.team__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.team-card {
+  background: var(--color-card);
+  border-radius: var(--radius-md);
+  padding: 28px;
+  display: grid;
+  gap: 16px;
+  text-align: center;
+  box-shadow: var(--shadow-card);
+}
+
+.team-card__avatar {
+  width: 96px;
+  height: 96px;
+  margin: 0 auto;
+  border-radius: 32px;
+  background: linear-gradient(135deg, rgba(255, 95, 60, 0.6), rgba(15, 23, 42, 0.95));
+}
+
+.team-card__avatar--lead {
+  background-image: linear-gradient(135deg, #f97316, #111827);
+}
+
+.team-card__avatar--coach {
+  background-image: linear-gradient(135deg, #38bdf8, #0f172a);
+}
+
+.team-card__avatar--performance {
+  background-image: linear-gradient(135deg, #22d3ee, #1f2937);
+}
+
+.team-card__avatar--community {
+  background-image: linear-gradient(135deg, #a855f7, #111827);
+}
+
+.cta {
+  background: linear-gradient(120deg, rgba(255, 95, 60, 0.65), rgba(6, 11, 26, 0.95));
+}
+
+.cta__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.cta__copy {
+  max-width: 560px;
+  display: grid;
+  gap: 12px;
+}
+
+.site-footer {
+  background: #050a1a;
+  padding: 32px 0;
+}
+
+@media (max-width: 768px) {
+  .timeline__list li {
+    grid-template-columns: 1fr;
+  }
+
+  .cta__inner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/assets/css/auth.css
+++ b/assets/css/auth.css
@@ -1,0 +1,220 @@
+.auth-page {
+  background: var(--color-background);
+  color: #f8fafc;
+}
+
+.auth-hero {
+  padding: 96px 0 80px;
+  background: var(--color-section);
+}
+
+.auth-hero__inner {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 48px;
+  align-items: stretch;
+}
+
+.auth-hero__content {
+  display: grid;
+  gap: 20px;
+}
+
+.auth-hero__content h1 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(2.25rem, 1.7rem + 1.2vw, 3.2rem);
+}
+
+.auth-hero__content p {
+  color: var(--color-muted-light);
+  margin: 0;
+}
+
+.auth-hero__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px 24px;
+  color: var(--color-muted-light);
+  font-size: 0.95rem;
+}
+
+.auth-card {
+  background: var(--color-card);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-card);
+  padding: 40px;
+  display: grid;
+  gap: 24px;
+}
+
+.auth-card h2 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.75rem;
+}
+
+.auth-card p {
+  margin: 0;
+  color: var(--color-muted-light);
+}
+
+.auth-card form {
+  display: grid;
+  gap: 20px;
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.field-label {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.auth-card .btn {
+  padding: 14px 32px;
+}
+
+.form-note {
+  font-size: 0.9rem;
+  color: var(--color-muted-light);
+}
+
+.field-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 0.95rem;
+  color: var(--color-muted-light);
+}
+
+.field-checkbox input[type='checkbox'] {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--color-primary);
+}
+
+.form-message {
+  padding: 12px 16px;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.form-message[hidden] {
+  display: none;
+}
+
+.form-message--error {
+  background: rgba(239, 68, 68, 0.15);
+  color: #fecaca;
+  border: 1px solid rgba(248, 113, 113, 0.4);
+}
+
+.form-message--success {
+  background: rgba(16, 185, 129, 0.15);
+  color: #a7f3d0;
+  border: 1px solid rgba(52, 211, 153, 0.4);
+}
+
+.auth-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 24px;
+  font-size: 0.95rem;
+}
+
+.auth-links a {
+  color: var(--color-accent);
+  font-weight: 600;
+}
+
+.auth-benefits {
+  padding: 72px 0 96px;
+}
+
+.auth-benefits__inner {
+  display: grid;
+  gap: 48px;
+}
+
+.benefits-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 24px;
+}
+
+.benefit-card {
+  background: var(--color-card);
+  border-radius: var(--radius-md);
+  padding: 28px;
+  display: grid;
+  gap: 12px;
+  position: relative;
+  overflow: hidden;
+}
+
+.benefit-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(255, 95, 60, 0.16), rgba(15, 23, 42, 0.8));
+  mix-blend-mode: screen;
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.benefit-card h3 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.4rem;
+}
+
+.benefit-card p {
+  margin: 0;
+  color: var(--color-muted-light);
+}
+
+.auth-summary {
+  display: grid;
+  gap: 16px;
+  color: var(--color-muted-light);
+  font-size: 0.95rem;
+}
+
+.auth-summary strong {
+  color: #fff;
+}
+
+@media (max-width: 1023px) {
+  .auth-hero__inner {
+    grid-template-columns: 1fr;
+  }
+
+  .auth-card {
+    max-width: 560px;
+    margin: 0 auto;
+  }
+
+  .form-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 767px) {
+  .auth-hero {
+    padding: 72px 0 64px;
+  }
+
+  .auth-card {
+    padding: 32px 24px;
+  }
+
+  .benefits-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1,0 +1,128 @@
+:root {
+  --color-primary: #ff5f3c;
+  --color-primary-dark: #e14c2b;
+  --color-accent: #ffd166;
+  --color-surface: #ffffff;
+  --color-surface-alt: #0c1324;
+  --color-muted: #64748b;
+  --color-muted-light: #94a3b8;
+  --color-border: rgba(255, 255, 255, 0.16);
+  --color-background: #060b1a;
+  --color-section: #0f172a;
+  --color-card: #101a32;
+  --color-card-alt: #13203a;
+  --color-highlight: rgba(255, 209, 102, 0.08);
+  --gradient-hero: linear-gradient(135deg, rgba(255, 95, 60, 0.9), rgba(6, 11, 26, 0.92));
+  --gradient-card: linear-gradient(160deg, rgba(255, 95, 60, 0.18), rgba(6, 11, 26, 0.8));
+  --font-base: 'Barlow', 'Noto Sans TC', sans-serif;
+  --font-display: 'Rajdhani', 'Noto Sans TC', sans-serif;
+  --container-width: min(1156px, 100% - 48px);
+  --container-narrow: min(940px, 100% - 48px);
+  --radius-lg: 28px;
+  --radius-md: 20px;
+  --radius-sm: 12px;
+  --shadow-soft: 0 20px 60px rgba(4, 9, 20, 0.35);
+  --shadow-card: 0 12px 40px rgba(4, 9, 20, 0.25);
+  color-scheme: dark light;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  font-size: 16px;
+  scroll-behavior: smooth;
+  background-color: var(--color-background);
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-base);
+  background-color: var(--color-background);
+  color: #f8fafc;
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: var(--color-accent);
+}
+
+img,
+svg {
+  max-width: 100%;
+  display: block;
+}
+
+section {
+  padding: 72px 0;
+}
+
+.wrapper {
+  width: var(--container-width);
+  margin: 0 auto;
+}
+
+.form-group {
+  display: grid;
+  gap: 8px;
+}
+
+input,
+select,
+textarea {
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: var(--radius-sm);
+  padding: 12px 16px;
+  color: #fff;
+  font: inherit;
+}
+
+textarea {
+  resize: vertical;
+}
+
+@media (max-width: 767px) {
+  :root {
+    --container-width: min(100% - 32px, 720px);
+    --container-narrow: min(100% - 32px, 640px);
+  }
+
+  section {
+    padding: 56px 0;
+  }
+}
+
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: 16px;
+  background: var(--color-accent);
+  color: #0f172a;
+  padding: 12px 18px;
+  border-radius: 999px;
+  font-weight: 600;
+  z-index: 999;
+}
+
+.skip-link:focus {
+  left: 16px;
+}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -1,0 +1,290 @@
+.topbar {
+  background: rgba(15, 23, 42, 0.85);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+  font-size: 0.875rem;
+}
+
+.topbar__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 10px 0;
+}
+
+.topbar__contact {
+  display: flex;
+  gap: 24px;
+  color: var(--color-muted-light);
+}
+
+.topbar__contact a:hover,
+.topbar__contact a:focus {
+  color: #fff;
+}
+
+.social-list {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: rgba(6, 11, 26, 0.92);
+  backdrop-filter: blur(16px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.site-header__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 18px 0;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.brand__mark {
+  width: 40px;
+  height: 40px;
+  display: grid;
+  place-items: center;
+  border-radius: 12px;
+  background: var(--gradient-hero);
+  font-family: var(--font-display);
+  font-size: 1.2rem;
+}
+
+.site-nav {
+  margin-left: auto;
+}
+
+.site-nav__toggle {
+  display: none;
+  background: transparent;
+  color: #fff;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  padding: 8px 16px;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+}
+
+.site-nav__list {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.site-nav__list a {
+  padding: 8px 0;
+  display: inline-block;
+  transition: color 0.2s ease;
+}
+
+.site-nav__list a:hover,
+.site-nav__list a:focus {
+  color: var(--color-accent);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border-radius: 999px;
+  font-weight: 700;
+  text-transform: none;
+  letter-spacing: 0.04em;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.btn span,
+.btn strong {
+  letter-spacing: inherit;
+}
+
+.btn--accent {
+  background: var(--color-accent);
+  color: #0f172a;
+  padding: 12px 28px;
+}
+
+.btn--accent:hover,
+.btn--accent:focus {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-card);
+}
+
+.btn--primary {
+  background: var(--color-primary);
+  color: #fff;
+  padding: 12px 32px;
+}
+
+.btn--primary:hover,
+.btn--primary:focus {
+  background: var(--color-primary-dark);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-card);
+}
+
+.btn--ghost {
+  background: transparent;
+  color: #fff;
+  padding: 12px 28px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+}
+
+.btn--ghost:hover,
+.btn--ghost:focus {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.section-head {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 32px;
+}
+
+.section-head--center {
+  align-items: center;
+  text-align: center;
+}
+
+.eyebrow {
+  font-family: var(--font-display);
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  font-weight: 600;
+  color: var(--color-accent);
+  font-size: 0.875rem;
+}
+
+.section-title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(2rem, 1.4rem + 1.5vw, 2.8rem);
+  margin: 0;
+}
+
+.card-surface {
+  background: var(--color-card);
+  border-radius: var(--radius-md);
+  padding: 32px;
+  box-shadow: var(--shadow-card);
+}
+
+.image-note {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 8px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.8);
+  background: rgba(15, 23, 42, 0.6);
+  backdrop-filter: blur(8px);
+}
+
+.image-note--overlay {
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  z-index: 2;
+  margin-top: 0;
+  pointer-events: none;
+}
+
+.image-note--subtle {
+  background: transparent;
+  padding: 0;
+  letter-spacing: 0.08em;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+@media (max-width: 1024px) {
+  .topbar__inner {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .topbar__contact {
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+
+  .site-header__inner {
+    gap: 16px;
+  }
+
+  .site-nav__list {
+    gap: 16px;
+  }
+}
+
+@media (max-width: 768px) {
+  .site-nav__toggle {
+    display: inline-flex;
+  }
+
+  .site-nav__list {
+    position: absolute;
+    inset: 72px 16px auto;
+    flex-direction: column;
+    background: rgba(6, 11, 26, 0.96);
+    padding: 20px;
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-soft);
+    transform-origin: top right;
+    transform: scale(0.9);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+  }
+
+  .site-nav__list.is-open {
+    opacity: 1;
+    pointer-events: auto;
+    transform: scale(1);
+  }
+
+  .site-nav__list li {
+    width: 100%;
+    text-align: center;
+  }
+}

--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -1,0 +1,722 @@
+.hero {
+  position: relative;
+  display: grid;
+  align-items: stretch;
+  min-height: clamp(560px, 78vh, 760px);
+  width: 100%;
+  padding: 0;
+  overflow: hidden;
+  background: transparent;
+}
+
+.hero__slides {
+  position: relative;
+  display: grid;
+  overflow: hidden;
+  height: 100%;
+  min-height: inherit;
+  z-index: 1;
+}
+
+.hero-slide {
+  position: relative;
+  grid-area: 1 / 1;
+  display: grid;
+  align-items: center;
+  min-height: inherit;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.6s ease;
+}
+
+.hero-slide.is-active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.hero-slide__media {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  z-index: 0;
+  opacity: 0;
+  transition: opacity 0.6s ease;
+}
+
+.hero-slide__media::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(6, 11, 26, 0.2), rgba(6, 11, 26, 0.78));
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* Hero carousel placeholder建議使用 1920x1080px 的運動照片，可直接替換 img src */
+.hero-slide__media img {
+  position: relative;
+  z-index: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover;
+  filter: saturate(1.1);
+}
+
+.hero-slide.is-active .hero-slide__media {
+  opacity: 1;
+}
+
+
+
+.hero-slide__inner {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: clamp(96px, 16vh, 160px) 0;
+}
+
+.hero-slide__content {
+  max-width: 640px;
+  width: min(100%, 640px);
+  display: grid;
+  gap: 20px;
+  text-align: center;
+  justify-items: center;
+  align-items: center;
+}
+
+.hero-slide__title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(2.4rem, 2rem + 1.5vw, 3.4rem);
+}
+
+.hero-slide__text {
+  color: var(--color-muted-light);
+  margin: 0;
+}
+
+.hero-slide__actions {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.hero__dots,
+.testimonial__dots {
+  position: absolute;
+  display: flex;
+  gap: 12px;
+  bottom: 36px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 3;
+  pointer-events: auto;
+}
+
+.hero__dots button,
+.testimonial__dots button {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 0;
+  background: rgba(255, 255, 255, 0.35);
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.hero__dots button.is-active,
+.testimonial__dots button.is-active {
+  background: var(--color-accent);
+  transform: scale(1.1);
+}
+
+.partners {
+  background: var(--color-section);
+  padding: 28px 0;
+  border-top: 1px solid rgba(148, 163, 184, 0.12);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.partner-list {
+  display: grid;
+  grid-auto-flow: column;
+  justify-content: space-between;
+  gap: 32px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: 600;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--color-muted-light);
+}
+
+.feature-grid {
+  background: var(--color-section);
+}
+
+.feature-grid__list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 20px;
+}
+
+.feature-card {
+  background: var(--color-card);
+  border-radius: var(--radius-md);
+  padding: 32px;
+  display: grid;
+  gap: 16px;
+  min-height: 220px;
+  box-shadow: var(--shadow-card);
+}
+
+.feature-card__icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  background: var(--gradient-card);
+}
+
+.programs {
+  background: var(--color-background);
+}
+
+.programs__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 20px;
+}
+
+.program-card {
+  display: grid;
+  grid-template-rows: 200px 1fr;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: var(--color-card);
+  box-shadow: var(--shadow-card);
+}
+
+.program-card__media {
+  /* 可用 640x420px 運動課程照片直接覆蓋 background-image */
+  background: linear-gradient(135deg, rgba(255, 95, 60, 0.65), rgba(15, 23, 42, 0.9));
+}
+
+.program-card__body {
+  padding: 28px;
+  display: grid;
+  gap: 12px;
+}
+
+.program-card__link {
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-accent);
+}
+
+.sports {
+  background: var(--color-section);
+}
+
+.sports__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.sports-card {
+  padding: 28px;
+  background: var(--color-card);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-card);
+  display: grid;
+  gap: 12px;
+}
+
+.stats {
+  background: var(--color-background);
+}
+
+.stats__inner {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 20px;
+}
+
+.stat {
+  background: var(--color-card);
+  border-radius: var(--radius-md);
+  padding: 32px;
+  display: grid;
+  gap: 8px;
+  text-align: center;
+  box-shadow: var(--shadow-card);
+}
+
+.stat__value {
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 1.4rem + 2vw, 3.4rem);
+  font-weight: 700;
+}
+
+.stat__label {
+  color: var(--color-muted-light);
+}
+
+.schedule {
+  background: var(--color-section);
+}
+
+.schedule__inner {
+  display: grid;
+  gap: 24px;
+}
+
+.schedule__table {
+  display: grid;
+  gap: 12px;
+}
+
+.schedule__row {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  background: var(--color-card);
+  border-radius: var(--radius-md);
+  padding: 18px 24px;
+  box-shadow: var(--shadow-card);
+}
+
+.schedule__row--head {
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: var(--color-card-alt);
+}
+
+.gallery {
+  background: var(--color-background);
+}
+
+.gallery__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 12px;
+}
+
+.gallery__item {
+  border-radius: var(--radius-md);
+  min-height: 220px;
+  background-size: cover;
+  background-position: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.gallery__item::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(160deg, rgba(6, 11, 26, 0.05), rgba(6, 11, 26, 0.6));
+}
+
+.gallery__item--court {
+  background-image: linear-gradient(120deg, #ff7e5f, #1f2937);
+}
+
+.gallery__item--pool {
+  background-image: linear-gradient(135deg, #38bdf8, #0f172a);
+}
+
+.gallery__item--gym {
+  background-image: linear-gradient(135deg, #f97316, #111827);
+}
+
+.gallery__item--arena {
+  background-image: linear-gradient(135deg, #f43f5e, #1f2937);
+}
+
+.gallery__item--soccer {
+  background-image: linear-gradient(135deg, #34d399, #0f172a);
+}
+
+.gallery__item--lounge {
+  background-image: linear-gradient(135deg, #a855f7, #111827);
+}
+
+.plans {
+  background: var(--color-section);
+}
+
+.plans__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 20px;
+}
+
+.plan-card {
+  background: var(--color-card);
+  border-radius: var(--radius-md);
+  padding: 32px;
+  display: grid;
+  gap: 16px;
+  text-align: center;
+  box-shadow: var(--shadow-card);
+}
+
+.plan-card__price {
+  font-family: var(--font-display);
+  font-size: 2.6rem;
+  margin: 0;
+}
+
+.plan-card__price span {
+  font-size: 1rem;
+  color: var(--color-muted-light);
+}
+
+.plan-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 10px;
+  color: var(--color-muted-light);
+}
+
+.plan-card--featured {
+  background: linear-gradient(135deg, rgba(255, 95, 60, 0.2), rgba(17, 24, 39, 0.98));
+  border: 1px solid rgba(255, 209, 102, 0.45);
+  transform: translateY(-6px);
+}
+
+.plan-card__badge {
+  font-size: 0.875rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-accent);
+}
+
+.coaches {
+  background: var(--color-background);
+}
+
+.coaches__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.coach-card {
+  background: var(--color-card);
+  border-radius: var(--radius-md);
+  display: grid;
+  gap: 16px;
+  padding: 28px;
+  text-align: center;
+  box-shadow: var(--shadow-card);
+}
+
+.coach-card__avatar {
+  width: 96px;
+  height: 96px;
+  margin: 0 auto;
+  border-radius: 32px;
+  background: var(--gradient-card);
+}
+
+.testimonials {
+  background: var(--color-section);
+}
+
+.testimonial-slider {
+  position: relative;
+  display: grid;
+  gap: 24px;
+  padding-bottom: 56px;
+}
+
+.testimonial-slider__viewport {
+  position: relative;
+  display: grid;
+  min-height: clamp(260px, 32vw, 340px);
+  isolation: isolate;
+}
+
+.testimonial {
+  grid-area: 1 / 1;
+  background: var(--color-card);
+  border-radius: var(--radius-md);
+  padding: clamp(28px, 4vw, 44px);
+  display: grid;
+  gap: 16px;
+  justify-items: center;
+  text-align: center;
+  box-shadow: var(--shadow-card);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.4s ease;
+}
+
+.testimonial.is-active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.testimonial__author {
+  color: var(--color-muted-light);
+}
+
+.news {
+  background: var(--color-background);
+}
+
+.news__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 20px;
+}
+
+.news-card {
+  background: var(--color-card);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  box-shadow: var(--shadow-card);
+}
+
+.news-card__media {
+  height: 180px;
+  background-size: cover;
+  background-position: center;
+}
+
+.news-card__body {
+  padding: 28px;
+  display: grid;
+  gap: 12px;
+}
+
+.news-card__date {
+  color: var(--color-muted-light);
+  font-size: 0.875rem;
+}
+
+.news-card__link {
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-accent);
+}
+
+.news-card__media--league {
+  background-image: linear-gradient(135deg, #f97316, #111827);
+}
+
+.news-card__media--clinic {
+  background-image: linear-gradient(135deg, #0ea5e9, #1e293b);
+}
+
+.news-card__media--community {
+  background-image: linear-gradient(135deg, #22d3ee, #0f172a);
+}
+
+.cta {
+  background: linear-gradient(120deg, rgba(255, 95, 60, 0.65), rgba(6, 11, 26, 0.95));
+}
+
+.cta__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.cta__copy {
+  max-width: 520px;
+  display: grid;
+  gap: 12px;
+}
+
+.contact {
+  background: var(--color-section);
+}
+
+.contact__inner {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 40px;
+}
+
+.contact__form {
+  background: var(--color-card);
+  border-radius: var(--radius-md);
+  padding: 32px;
+  display: grid;
+  gap: 20px;
+  box-shadow: var(--shadow-card);
+}
+
+.site-footer {
+  background: #050a1a;
+  color: var(--color-muted-light);
+}
+
+.site-footer__top {
+  display: grid;
+  grid-template-columns: 1.2fr repeat(2, 0.8fr) 1.1fr;
+  gap: 32px;
+  padding: 72px 0 48px;
+}
+
+.site-footer__top ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.site-footer__top h3 {
+  margin: 0 0 16px;
+  font-family: var(--font-display);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: #fff;
+}
+
+.site-footer__newsletter form {
+  display: flex;
+  gap: 12px;
+}
+
+.site-footer__newsletter input {
+  flex: 1;
+}
+
+.site-footer__bottom {
+  border-top: 1px solid rgba(148, 163, 184, 0.15);
+  padding: 20px 0;
+}
+
+.site-footer__bottom-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.program-card__media--tennis {
+  background-image: linear-gradient(135deg, #38bdf8, #1f2937);
+}
+
+.program-card__media--basketball {
+  background-image: linear-gradient(135deg, #f97316, #111827);
+}
+
+.program-card__media--swim {
+  background-image: linear-gradient(135deg, #22d3ee, #0f172a);
+}
+
+.program-card__media--fitness {
+  background-image: linear-gradient(135deg, #a855f7, #111827);
+}
+
+.coach-card__avatar--tennis {
+  background-image: linear-gradient(135deg, #38bdf8, #1f2937);
+}
+
+.coach-card__avatar--basketball {
+  background-image: linear-gradient(135deg, #f97316, #111827);
+}
+
+.coach-card__avatar--swim {
+  background-image: linear-gradient(135deg, #0ea5e9, #1e293b);
+}
+
+.coach-card__avatar--soccer {
+  background-image: linear-gradient(135deg, #34d399, #0f172a);
+}
+
+@media (max-width: 1024px) {
+  .hero-slide__content {
+    max-width: 480px;
+  }
+
+  .cta__inner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 768px) {
+  .hero__slides {
+    min-height: clamp(500px, 95vh, 680px);
+  }
+
+  .hero-slide {
+    min-height: auto;
+  }
+
+  .hero-slide__inner {
+    padding: clamp(120px, 28vh, 208px) 0 96px;
+    justify-content: center;
+  }
+
+  .hero-slide__content {
+    text-align: center;
+    justify-items: center;
+    align-items: center;
+  }
+
+  .hero-slide__actions {
+    justify-content: center;
+  }
+
+  .partner-list {
+    grid-auto-flow: row;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    text-align: center;
+  }
+
+  .schedule__row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .contact__inner {
+    grid-template-columns: 1fr;
+  }
+
+  .site-footer__top {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 600px) {
+  .hero-slide__content {
+    gap: 16px;
+  }
+
+  .hero__dots,
+  .testimonial__dots {
+    bottom: 24px;
+  }
+
+  .program-card {
+    grid-template-rows: 180px 1fr;
+  }
+
+  .news-card__media {
+    height: 160px;
+  }
+}

--- a/assets/css/member.css
+++ b/assets/css/member.css
@@ -1,0 +1,255 @@
+.page-member {
+  background: var(--color-background);
+  color: #f8fafc;
+}
+
+.dashboard-hero {
+  background: var(--gradient-hero);
+  padding: 96px 0 88px;
+  position: relative;
+  overflow: hidden;
+}
+
+.dashboard-hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(255, 209, 102, 0.2), transparent 60%);
+  pointer-events: none;
+}
+
+.dashboard-hero__inner {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 28px;
+  max-width: 720px;
+}
+
+.dashboard-hero__inner h1 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(2.4rem, 1.8rem + 1.5vw, 3.4rem);
+}
+
+.dashboard-hero__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px 24px;
+  color: rgba(248, 250, 252, 0.85);
+}
+
+.dashboard-hero__goal {
+  margin: 0;
+  color: rgba(248, 250, 252, 0.85);
+  font-size: 1rem;
+}
+
+.dashboard-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.dashboard-section {
+  padding: 80px 0;
+}
+
+.dashboard-section--alt {
+  background: var(--color-section);
+}
+
+.dashboard-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 16px;
+  margin-bottom: 40px;
+}
+
+.dashboard-head h2 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(1.8rem, 1.4rem + 0.8vw, 2.4rem);
+}
+
+.dashboard-head p {
+  margin: 0;
+  color: var(--color-muted-light);
+}
+
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 24px;
+}
+
+.stat-card {
+  background: var(--color-card);
+  border-radius: var(--radius-md);
+  padding: 28px;
+  display: grid;
+  gap: 12px;
+  box-shadow: var(--shadow-card);
+}
+
+.stat-card h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--color-accent);
+}
+
+.stat-card strong {
+  font-family: var(--font-display);
+  font-size: 2rem;
+}
+
+.stat-card p {
+  margin: 0;
+  color: var(--color-muted-light);
+}
+
+.dashboard-actions__grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 24px;
+}
+
+.action-card {
+  background: var(--color-card);
+  border-radius: var(--radius-md);
+  padding: 24px;
+  display: grid;
+  gap: 16px;
+  position: relative;
+  overflow: hidden;
+  min-height: 180px;
+}
+
+.action-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(160deg, rgba(255, 95, 60, 0.18), rgba(15, 23, 42, 0.85));
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.action-card h3 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.4rem;
+}
+
+.action-card p {
+  margin: 0;
+  color: var(--color-muted-light);
+}
+
+.action-card a {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-accent);
+}
+
+.schedule-grid {
+  display: grid;
+  gap: 20px;
+}
+
+.schedule-card {
+  background: var(--color-card);
+  border-radius: var(--radius-md);
+  padding: 24px;
+  display: grid;
+  gap: 12px;
+  box-shadow: var(--shadow-card);
+}
+
+.schedule-card header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 20px;
+  align-items: baseline;
+}
+
+.schedule-card time {
+  font-family: var(--font-display);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-accent);
+  font-size: 0.95rem;
+}
+
+.schedule-card h3 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.schedule-card p {
+  margin: 0;
+  color: var(--color-muted-light);
+}
+
+.schedule-card ul {
+  margin: 0;
+  padding-left: 20px;
+  color: var(--color-muted-light);
+}
+
+.dashboard-updates {
+  display: grid;
+  gap: 20px;
+}
+
+.update-card {
+  background: var(--color-card);
+  border-radius: var(--radius-md);
+  padding: 24px;
+  display: grid;
+  gap: 12px;
+  box-shadow: var(--shadow-card);
+}
+
+.update-card h3 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.update-card p {
+  margin: 0;
+  color: var(--color-muted-light);
+}
+
+@media (max-width: 1023px) {
+  .stat-grid,
+  .dashboard-actions__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 767px) {
+  .dashboard-hero {
+    padding: 80px 0 64px;
+  }
+
+  .dashboard-section {
+    padding: 64px 0;
+  }
+
+  .dashboard-head {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .stat-grid,
+  .dashboard-actions__grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/assets/css/shop.css
+++ b/assets/css/shop.css
@@ -1,0 +1,583 @@
+body {
+  background: var(--color-background);
+  color: #f8fafc;
+}
+
+.page-shop section {
+  padding: 48px 0;
+}
+
+.page-shop .section-head {
+  margin-bottom: 24px;
+  gap: 8px;
+}
+
+.site-header--plain {
+  background: rgba(6, 11, 26, 0.92);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  position: sticky;
+  top: 0;
+  z-index: 50;
+}
+
+.hero.hero--shop {
+  position: relative;
+  display: grid;
+  align-items: stretch;
+  width: 100%;
+  padding: 0;
+  overflow: hidden;
+  background: transparent;
+  min-height: clamp(520px, 72vh, 700px);
+}
+
+.hero--shop .hero__slides {
+  position: relative;
+  display: grid;
+  overflow: hidden;
+  height: 100%;
+  min-height: inherit;
+  z-index: 1;
+}
+
+.hero--shop .hero-slide {
+  position: relative;
+  grid-area: 1 / 1;
+  display: grid;
+  align-items: center;
+  min-height: inherit;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.6s ease;
+}
+
+.hero--shop .hero-slide.is-active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.hero--shop .hero-slide__media {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  z-index: 0;
+  opacity: 0;
+  transition: opacity 0.6s ease;
+}
+
+.hero--shop .hero-slide__media::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(6, 11, 26, 0.2), rgba(6, 11, 26, 0.78));
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* Shop hero placeholder建議使用 1600x900px 網球照片，可直接替換 img src */
+.hero--shop .hero-slide__media img {
+  position: relative;
+  z-index: 0;
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover;
+  filter: saturate(1.08);
+}
+
+.hero--shop .hero-slide.is-active .hero-slide__media {
+  opacity: 1;
+}
+
+
+.hero--shop .hero-slide__inner {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: clamp(88px, 14vh, 160px) 0;
+}
+
+.hero--shop .hero-slide__content {
+  max-width: 560px;
+  width: min(100%, 560px);
+  display: grid;
+  justify-items: center;
+  align-items: center;
+  text-align: center;
+  gap: 18px;
+  background: rgba(6, 11, 26, 0.78);
+  padding: 32px 36px;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+}
+
+.hero--shop .hero-slide__content h1,
+.hero--shop .hero-slide__content h2 {
+  font-size: clamp(2.4rem, 2rem + 1.2vw, 3.2rem);
+}
+
+.hero--shop .hero-slide__content p {
+  color: var(--color-muted-light);
+}
+
+.hero--shop .hero-slide__actions {
+  justify-content: center;
+}
+
+.hero--shop .hero__dots {
+  position: absolute;
+  display: flex;
+  gap: 12px;
+  bottom: 36px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 3;
+  pointer-events: auto;
+}
+
+.hero--shop .hero__dots button {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 0;
+  background: rgba(255, 255, 255, 0.32);
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.hero--shop .hero__dots button.is-active {
+  background: var(--color-accent);
+  transform: scale(1.1);
+}
+
+.usp {
+  background: var(--color-background);
+}
+
+.usp__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.usp-card {
+  background: var(--color-card);
+  border-radius: var(--radius-md);
+  padding: 24px;
+  display: grid;
+  gap: 10px;
+  text-align: center;
+  box-shadow: var(--shadow-card);
+}
+
+.categories {
+  background: var(--color-section);
+}
+
+.categories__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.category-card {
+  background: var(--color-card);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  display: grid;
+  grid-template-rows: 200px 1fr;
+  box-shadow: var(--shadow-card);
+}
+
+.category-card__media {
+  /* 建議以 520x360px 網球商品照片取代下列漸層 */
+  position: relative;
+  background-size: cover;
+  background-position: center;
+}
+
+.category-card__media--racket {
+  background-image: linear-gradient(135deg, #0ea5e9, #1e293b);
+}
+
+.category-card__media--shoe {
+  background-image: linear-gradient(135deg, #f97316, #111827);
+}
+
+.category-card__media--apparel {
+  background-image: linear-gradient(135deg, #a855f7, #0f172a);
+}
+
+.category-card__media--gear {
+  background-image: linear-gradient(135deg, #22d3ee, #0f172a);
+}
+
+.category-card__body {
+  padding: 24px;
+  display: grid;
+  gap: 10px;
+}
+
+.featured {
+  background: var(--color-background);
+}
+
+
+
+
+.featured__header {
+  display: grid;
+  gap: clamp(24px, 3vw, 36px);
+  align-items: start;
+  grid-template-columns: minmax(0, 1fr);
+  margin-bottom: clamp(28px, 3vw, 40px);
+  width: 100%;
+}
+
+.featured__intro {
+  display: grid;
+  gap: 18px;
+  align-content: start;
+  width: 100%;
+}
+
+.featured__title-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.featured__title-bar .eyebrow {
+  margin: 0;
+}
+
+.featured__title-bar .section-title {
+  margin: 0;
+}
+
+.featured__intro p {
+  margin: 0;
+  color: var(--color-muted-light);
+  line-height: 1.6;
+}
+
+.featured__highlight {
+  height: auto;
+  width: 100%;
+  justify-self: start;
+}
+
+.featured-grid {
+  grid-area: grid;
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  align-content: start;
+}
+
+.product-card {
+  background: var(--color-card);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  box-shadow: var(--shadow-card);
+  min-height: 100%;
+}
+
+.product-card__media {
+  position: relative;
+  margin: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: clamp(18px, 2vw, 24px);
+  background: rgba(15, 23, 42, 0.5);
+  min-height: 220px;
+}
+
+.product-card__media img {
+  max-width: 100%;
+  height: auto;
+  object-fit: contain;
+}
+
+.product-card__body {
+  display: grid;
+  gap: 14px;
+  padding: 24px;
+  align-content: start;
+}
+
+.product-card__body p {
+  color: var(--color-muted-light);
+}
+
+.product-card__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.product-card__price {
+  font-family: var(--font-display);
+  font-size: 1.3rem;
+  color: #fcd34d;
+}
+
+.bundle-card {
+  background: var(--color-card);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+  align-items: stretch;
+  box-shadow: var(--shadow-elevated);
+}
+
+.bundle-card__media {
+  position: relative;
+  margin: 0;
+  background: rgba(15, 23, 42, 0.4);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(16px, 2vw, 24px);
+}
+
+.bundle-card__media img {
+  display: block;
+  max-width: 960px;
+  width: 100%;
+  height: auto;
+}
+
+.bundle-card__content {
+  padding: clamp(28px, 3vw, 40px);
+  display: grid;
+  gap: clamp(18px, 2vw, 26px);
+  align-content: start;
+}
+
+.bundle-card__header {
+  display: grid;
+  gap: 12px;
+}
+
+.bundle-card__header h3 {
+  margin: 0;
+  font-size: clamp(1.8rem, 1.5rem + 0.6vw, 2.2rem);
+}
+
+.bundle-card__includes {
+  padding: clamp(18px, 2vw, 24px);
+  border-radius: var(--radius-md);
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  display: grid;
+  gap: 12px;
+}
+
+.bundle-card__includes h4 {
+  margin: 0;
+  font-size: 1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.86);
+}
+
+.bundle-card__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+  color: var(--color-muted-light);
+}
+
+.bundle-card__footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.bundle-card__price {
+  font-family: var(--font-display);
+  font-size: 2rem;
+  color: #fcd34d;
+}
+
+.promos {
+  background: var(--color-section);
+}
+
+.promos__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 18px;
+}
+
+.promo-card {
+  border-radius: var(--radius-lg);
+  padding: 32px;
+  display: grid;
+  gap: 14px;
+  box-shadow: var(--shadow-card);
+}
+
+.promo-card--orange {
+  background: linear-gradient(135deg, rgba(249, 115, 22, 0.75), rgba(15, 23, 42, 0.9));
+}
+
+.promo-card--blue {
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.75), rgba(15, 23, 42, 0.9));
+}
+
+.brands {
+  background: var(--color-background);
+  padding: 40px 0;
+}
+
+.brand-strip {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-auto-flow: column;
+  justify-content: space-between;
+  gap: 24px;
+  font-family: var(--font-display);
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: var(--color-muted-light);
+}
+
+.service {
+  background: var(--color-section);
+}
+
+.service__inner {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 32px;
+  align-items: center;
+}
+
+.service__media {
+  /* 以 720x480px 門市或服務照片取代可維持版面比例 */
+  position: relative;
+  min-height: 320px;
+  border-radius: var(--radius-lg);
+  background-image: linear-gradient(135deg, #a855f7, #0f172a);
+  box-shadow: var(--shadow-card);
+  overflow: hidden;
+}
+
+.service__content {
+  display: grid;
+  gap: 12px;
+}
+
+.service__content p {
+  color: var(--color-muted-light);
+}
+
+.service__content ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.newsletter {
+  background: linear-gradient(120deg, rgba(255, 95, 60, 0.5), rgba(6, 11, 26, 0.9));
+}
+
+.newsletter__inner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 24px;
+}
+
+.newsletter__copy {
+  display: grid;
+  gap: 12px;
+}
+
+.newsletter__form {
+  display: flex;
+  gap: 12px;
+}
+
+.newsletter__form input {
+  flex: 1;
+}
+
+.site-footer {
+  background: #050a1a;
+  padding: 32px 0;
+}
+
+@media (min-width: 720px) {
+  .featured-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 960px) {
+  .featured__header {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .featured__highlight {
+    margin-top: clamp(12px, 1.5vw, 24px);
+  }
+}
+
+@media (max-width: 1024px) {
+  .bundle-card {
+    grid-template-columns: 1fr;
+  }
+
+  .service__inner {
+    grid-template-columns: 1fr;
+  }
+
+  .brand-strip {
+    grid-auto-flow: row;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    text-align: center;
+  }
+}
+
+@media (max-width: 768px) {
+  .hero--shop .hero-slide__inner {
+    padding: 120px 0 96px;
+  }
+
+  .hero--shop .hero-slide__content {
+    padding: 24px 28px;
+  }
+
+  .newsletter__inner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .newsletter__form {
+    width: 100%;
+  }
+}

--- a/assets/images/hero-1-placeholder.svg
+++ b/assets/images/hero-1-placeholder.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080" role="img" aria-labelledby="title desc">
+  <title id="title">多項運動訓練示意圖</title>
+  <desc id="desc">藍橙色漸層背景，搭配抽象球場與跑道線條</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0ea5e9" />
+      <stop offset="100%" stop-color="#1e293b" />
+    </linearGradient>
+    <linearGradient id="overlay" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="rgba(14,165,233,0.3)" />
+      <stop offset="100%" stop-color="rgba(30,41,59,0.8)" />
+    </linearGradient>
+  </defs>
+  <rect width="1920" height="1080" fill="url(#bg)" />
+  <g fill="none" stroke="#38bdf8" stroke-width="12" opacity="0.45">
+    <rect x="240" y="200" width="1440" height="680" rx="80" />
+    <path d="M240 540h1440" />
+    <circle cx="960" cy="540" r="140" />
+    <path d="M480 200v880" opacity="0.5" />
+    <path d="M1440 200v880" opacity="0.3" />
+  </g>
+  <g fill="#facc15" opacity="0.55">
+    <circle cx="360" cy="320" r="120" />
+    <circle cx="1560" cy="760" r="140" />
+    <circle cx="700" cy="840" r="72" />
+  </g>
+  <text x="120" y="980" fill="rgba(255,255,255,0.65)" font-size="64" font-family="'Barlow', sans-serif">
+    建議以 1920 × 1080px 運動照片替換
+  </text>
+</svg>

--- a/assets/images/hero-2-placeholder.svg
+++ b/assets/images/hero-2-placeholder.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080" role="img" aria-labelledby="title desc">
+  <title id="title">教練指導團隊示意圖</title>
+  <desc id="desc">藍紫色漸層背景，搭配教練戰術板與球員剪影</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#6366f1" />
+      <stop offset="100%" stop-color="#0f172a" />
+    </linearGradient>
+  </defs>
+  <rect width="1920" height="1080" fill="url(#bg)" />
+  <g fill="#a855f7" opacity="0.7">
+    <path d="M420 220c80 0 120 60 120 120s-40 120-120 120-140-60-140-120 60-120 140-120z" />
+    <path d="M1500 600c120 0 220 84 220 188s-100 188-220 188-224-84-224-188 104-188 224-188z" opacity="0.45" />
+  </g>
+  <g fill="none" stroke="#bae6fd" stroke-width="14" opacity="0.55">
+    <rect x="560" y="220" width="800" height="640" rx="48" />
+    <path d="M560 360h800" />
+    <path d="M560 500h800" />
+    <path d="M960 220v860" opacity="0.35" />
+    <circle cx="960" cy="540" r="110" />
+  </g>
+  <text x="120" y="980" fill="rgba(226,232,240,0.75)" font-size="64" font-family="'Barlow', sans-serif">
+    建議以 1920 × 1080px 教練帶隊照片替換
+  </text>
+</svg>

--- a/assets/images/hero-3-placeholder.svg
+++ b/assets/images/hero-3-placeholder.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080" role="img" aria-labelledby="title desc">
+  <title id="title">競賽場館示意圖</title>
+  <desc id="desc">橘紫漸層背景與看台燈光，呈現賽事氛圍</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#f97316" />
+      <stop offset="100%" stop-color="#1e1b4b" />
+    </linearGradient>
+  </defs>
+  <rect width="1920" height="1080" fill="url(#bg)" />
+  <g fill="none" stroke="#fde68a" stroke-width="10" opacity="0.5">
+    <path d="M220 860c200-160 420-240 740-240s540 80 740 240" />
+    <path d="M220 840c200-160 420-240 740-240s540 80 740 240" opacity="0.4" />
+    <path d="M220 820c200-160 420-240 740-240s540 80 740 240" opacity="0.3" />
+  </g>
+  <g fill="#fbbf24" opacity="0.6">
+    <circle cx="340" cy="280" r="90" />
+    <circle cx="520" cy="220" r="60" />
+    <circle cx="1680" cy="260" r="110" />
+  </g>
+  <text x="120" y="980" fill="rgba(255,255,255,0.7)" font-size="64" font-family="'Barlow', sans-serif">
+    建議以 1920 × 1080px 賽事照片替換
+  </text>
+</svg>

--- a/assets/images/products/apparel-set.svg
+++ b/assets/images/products/apparel-set.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480" role="img" aria-labelledby="title desc">
+  <title id="title">網球服飾示意</title>
+  <desc id="desc">紫色漸層背景上的球衣與裙裝插畫，建議替換為商品照片</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#312e81" />
+      <stop offset="100%" stop-color="#8b5cf6" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="480" fill="url(#bg)" />
+  <path d="M160 360c0-60 20-150 60-210 30-40 120-40 150 0 40 60 60 150 60 210z" fill="#ede9fe" opacity="0.88" />
+  <path d="M200 220c40-24 120-24 160 0l-20-110c-40-30-80-30-120 0z" fill="#f9fafb" opacity="0.65" />
+  <rect x="320" y="260" width="160" height="150" rx="24" fill="#fcd34d" opacity="0.7" />
+  <circle cx="460" cy="200" r="70" fill="#f97316" opacity="0.6" />
+  <text x="36" y="440" fill="rgba(226,232,240,0.85)" font-size="28" font-family="'Barlow', sans-serif">建議以 640×480 服飾照片取代</text>
+</svg>

--- a/assets/images/products/bag-team.svg
+++ b/assets/images/products/bag-team.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480" role="img" aria-labelledby="title desc">
+  <title id="title">球袋配件示意</title>
+  <desc id="desc">青綠色背景上的球袋插畫，建議替換為商品照片</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#22d3ee" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="480" fill="url(#bg)" />
+  <rect x="120" y="180" width="420" height="200" rx="80" fill="#0ea5e9" opacity="0.7" />
+  <rect x="160" y="160" width="340" height="160" rx="70" fill="#38bdf8" opacity="0.65" />
+  <circle cx="220" cy="320" r="34" fill="#facc15" opacity="0.8" />
+  <circle cx="420" cy="320" r="34" fill="#facc15" opacity="0.5" />
+  <text x="32" y="440" fill="rgba(226,232,240,0.85)" font-size="28" font-family="'Barlow', sans-serif">替換為 640×480 球袋商品圖</text>
+</svg>

--- a/assets/images/products/feature-combo.svg
+++ b/assets/images/products/feature-combo.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 600" role="img" aria-labelledby="title desc">
+  <title id="title">網球拍鞋組合示意</title>
+  <desc id="desc">藍綠漸層背景搭配球拍、球鞋與網球，建議替換為橫式 960×600 商品照片</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#0ea5e9" />
+    </linearGradient>
+  </defs>
+  <rect width="960" height="600" fill="url(#bg)" />
+  <circle cx="720" cy="180" r="120" fill="#facc15" opacity="0.6" />
+  <ellipse cx="660" cy="420" rx="220" ry="70" fill="#0f172a" opacity="0.35" />
+  <path d="M360 440c160-160 220-280 220-360 0-60-40-80-80-80s-80 20-80 80c0 120 100 240 200 360" stroke="#f8fafc" stroke-width="28" fill="none" stroke-linecap="round" opacity="0.7" />
+  <rect x="240" y="360" width="180" height="160" rx="80" fill="#f97316" opacity="0.75" />
+  <rect x="500" y="340" width="220" height="120" rx="60" fill="#38bdf8" opacity="0.65" />
+  <text x="60" y="540" fill="rgba(226,232,240,0.8)" font-size="36" font-family="'Barlow', sans-serif">請替換為 960×600 網球商品橫幅照片</text>
+</svg>

--- a/assets/images/products/racket-pro.svg
+++ b/assets/images/products/racket-pro.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480" role="img" aria-labelledby="title desc">
+  <title id="title">網球拍商品示意</title>
+  <desc id="desc">綠色漸層背景上的網球拍與網球插畫，建議替換為商品照片</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#14b8a6" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="480" fill="url(#bg)" />
+  <circle cx="480" cy="160" r="70" fill="#facc15" opacity="0.75" />
+  <path d="M190 320c110-110 150-200 150-250 0-40-30-60-60-60s-60 20-60 60c0 80 70 180 140 250" stroke="#e2e8f0" stroke-width="20" fill="none" stroke-linecap="round" />
+  <ellipse cx="230" cy="100" rx="54" ry="70" fill="#0ea5e9" opacity="0.4" />
+  <rect x="300" y="330" width="80" height="120" rx="36" fill="#f97316" opacity="0.8" />
+  <text x="40" y="440" fill="rgba(226,232,240,0.75)" font-size="28" font-family="'Barlow', sans-serif">請換成 640×480 網球商品圖</text>
+</svg>

--- a/assets/images/products/shoe-speed.svg
+++ b/assets/images/products/shoe-speed.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480" role="img" aria-labelledby="title desc">
+  <title id="title">網球鞋商品示意</title>
+  <desc id="desc">藍橘色漸層背景上的球鞋圖樣，建議替換為商品照片</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1e3a8a" />
+      <stop offset="100%" stop-color="#f97316" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="480" fill="url(#bg)" />
+  <path d="M140 290c30-70 120-120 230-120 80 0 150 40 190 120-40 80-120 120-220 120-130 0-200-70-200-120z" fill="#f8fafc" opacity="0.88" />
+  <path d="M210 240h260l-46 130h-240z" fill="#0f172a" opacity="0.35" />
+  <circle cx="240" cy="350" r="32" fill="#94a3b8" opacity="0.6" />
+  <circle cx="430" cy="350" r="36" fill="#cbd5f5" opacity="0.5" />
+  <text x="36" y="440" fill="rgba(226,232,240,0.8)" font-size="28" font-family="'Barlow', sans-serif">建議使用 640×480 網球鞋商品照片</text>
+</svg>

--- a/assets/images/shop-hero-1.svg
+++ b/assets/images/shop-hero-1.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" role="img" aria-labelledby="title desc">
+  <title id="title">網球專賣店拍賣示意圖</title>
+  <desc id="desc">綠色球場背景與網球拍、網球圖形，建議替換為 1600×900 網球照片</desc>
+  <defs>
+    <linearGradient id="court" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#10b981" />
+      <stop offset="100%" stop-color="#0f172a" />
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#court)" />
+  <rect x="260" y="140" width="1080" height="620" rx="48" fill="none" stroke="#ecfdf5" stroke-width="12" opacity="0.7" />
+  <rect x="660" y="140" width="4" height="620" fill="#34d399" opacity="0.6" />
+  <circle cx="430" cy="280" r="120" fill="#facc15" opacity="0.7" />
+  <circle cx="1200" cy="640" r="160" fill="#fcd34d" opacity="0.5" />
+  <path d="M940 360c140-60 220-60 320 0" fill="none" stroke="#f87171" stroke-width="24" stroke-linecap="round" opacity="0.6" />
+  <text x="120" y="840" fill="rgba(226,232,240,0.75)" font-size="56" font-family="'Barlow', sans-serif">
+    建議以 1600 × 900px 網球產品或球場照片替換
+  </text>
+</svg>

--- a/assets/images/shop-hero-2.svg
+++ b/assets/images/shop-hero-2.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" role="img" aria-labelledby="title desc">
+  <title id="title">網球運動品牌牆示意</title>
+  <desc id="desc">深藍漸層背景搭配品牌徽章與網球線條，建議替換為 1600×900 網球品牌照片</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0ea5e9" />
+      <stop offset="100%" stop-color="#1e1b4b" />
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#bg)" />
+  <g fill="none" stroke="#bae6fd" stroke-width="10" opacity="0.5">
+    <circle cx="420" cy="320" r="120" />
+    <circle cx="780" cy="520" r="220" />
+    <circle cx="1180" cy="300" r="140" />
+  </g>
+  <g fill="#facc15" opacity="0.6">
+    <circle cx="580" cy="360" r="44" />
+    <circle cx="960" cy="500" r="56" />
+    <circle cx="1320" cy="340" r="40" />
+  </g>
+  <path d="M260 720h1080" stroke="#38bdf8" stroke-width="18" stroke-linecap="round" opacity="0.65" />
+  <text x="120" y="840" fill="rgba(226,232,240,0.8)" font-size="56" font-family="'Barlow', sans-serif">
+    建議以 1600 × 900px 品牌或門市照片替換
+  </text>
+</svg>

--- a/assets/images/shop-hero-3.svg
+++ b/assets/images/shop-hero-3.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" role="img" aria-labelledby="title desc">
+  <title id="title">網球比賽動態示意</title>
+  <desc id="desc">橘藍對比漸層與球網線條，建議替換為 1600×900 網球賽事照片</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f97316" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#bg)" />
+  <path d="M200 620h1200" stroke="#fde68a" stroke-width="16" stroke-linecap="round" opacity="0.6" />
+  <path d="M260 420h1080" stroke="#fef3c7" stroke-width="10" stroke-dasharray="40 24" opacity="0.6" />
+  <g fill="#facc15" opacity="0.65">
+    <circle cx="360" cy="320" r="100" />
+    <circle cx="1280" cy="500" r="80" />
+    <circle cx="940" cy="280" r="60" />
+  </g>
+  <text x="120" y="840" fill="rgba(255,255,255,0.78)" font-size="56" font-family="'Barlow', sans-serif">
+    建議以 1600 × 900px 網球賽事或訓練照片替換
+  </text>
+</svg>

--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -1,0 +1,349 @@
+const navToggle = document.querySelector('.site-nav__toggle');
+const navList = document.querySelector('.site-nav__list');
+
+if (navToggle && navList) {
+  navToggle.addEventListener('click', () => {
+    const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+    navToggle.setAttribute('aria-expanded', (!expanded).toString());
+    navList.classList.toggle('is-open');
+  });
+}
+
+function createCarousel(slideSelector, dotSelector, interval = 6000) {
+  const slides = document.querySelectorAll(slideSelector);
+  const dots = document.querySelectorAll(dotSelector);
+  if (!slides.length || !dots.length) return;
+
+  let index = 0;
+  let timer = null;
+
+  const setActive = (next) => {
+    slides[index].classList.remove('is-active');
+    slides[index].setAttribute('aria-hidden', 'true');
+    dots[index].classList.remove('is-active');
+    dots[index].setAttribute('aria-pressed', 'false');
+    index = next;
+    slides[index].classList.add('is-active');
+    slides[index].removeAttribute('aria-hidden');
+    dots[index].classList.add('is-active');
+    dots[index].setAttribute('aria-pressed', 'true');
+  };
+
+  const tick = () => {
+    const next = (index + 1) % slides.length;
+    setActive(next);
+  };
+
+  slides.forEach((slide) => {
+    if (!slide.classList.contains('is-active')) {
+      slide.setAttribute('aria-hidden', 'true');
+    }
+  });
+
+  dots.forEach((dot, dotIndex) => {
+    dot.setAttribute('aria-pressed', dot.classList.contains('is-active') ? 'true' : 'false');
+    dot.addEventListener('click', () => {
+      if (dotIndex === index) return;
+      clearInterval(timer);
+      setActive(dotIndex);
+      timer = setInterval(tick, interval);
+    });
+  });
+
+  timer = setInterval(tick, interval);
+}
+
+createCarousel('.hero:not(.hero--shop) .hero-slide', '.hero:not(.hero--shop) .hero__dots button');
+createCarousel('.hero--shop .hero-slide', '.hero--shop .hero__dots button', 7000);
+createCarousel('.testimonial', '.testimonial__dots button', 8000);
+
+const MEMBER_STORAGE_KEY = 'motionClubMember';
+const SESSION_STORAGE_KEY = 'motionClubSession';
+
+const canUseStorage = (() => {
+  try {
+    const testKey = '__motion_storage_test__';
+    window.localStorage.setItem(testKey, testKey);
+    window.localStorage.removeItem(testKey);
+    return true;
+  } catch (error) {
+    console.warn('本地儲存空間無法使用，會員資料僅會保留於此瀏覽器工作階段。', error);
+    return false;
+  }
+})();
+
+const storage = {
+  read(key) {
+    if (!canUseStorage) return null;
+    try {
+      return window.localStorage.getItem(key);
+    } catch (error) {
+      console.warn('讀取儲存資料時發生錯誤', error);
+      return null;
+    }
+  },
+  write(key, value) {
+    if (!canUseStorage) return false;
+    try {
+      window.localStorage.setItem(key, value);
+      return true;
+    } catch (error) {
+      console.warn('寫入儲存資料時發生錯誤', error);
+      return false;
+    }
+  },
+  remove(key) {
+    if (!canUseStorage) return;
+    try {
+      window.localStorage.removeItem(key);
+    } catch (error) {
+      console.warn('移除儲存資料時發生錯誤', error);
+    }
+  },
+};
+
+const getStoredMember = () => {
+  const raw = storage.read(MEMBER_STORAGE_KEY);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && parsed.email) {
+      return parsed;
+    }
+  } catch (error) {
+    console.warn('解析會員資料時發生錯誤', error);
+  }
+  return null;
+};
+
+const saveMember = (member) => {
+  if (!member || !member.email) return false;
+  return storage.write(MEMBER_STORAGE_KEY, JSON.stringify(member));
+};
+
+const getSessionEmail = () => storage.read(SESSION_STORAGE_KEY);
+const setSessionEmail = (email) => {
+  if (!email) {
+    storage.remove(SESSION_STORAGE_KEY);
+    return;
+  }
+  storage.write(SESSION_STORAGE_KEY, email);
+};
+
+const clearSession = () => storage.remove(SESSION_STORAGE_KEY);
+
+const isMemberLoggedIn = () => {
+  const member = getStoredMember();
+  const sessionEmail = getSessionEmail();
+  return Boolean(member && sessionEmail && member.email === sessionEmail);
+};
+
+const updateAuthUI = () => {
+  const loggedIn = isMemberLoggedIn();
+  document.querySelectorAll('[data-auth="guest"]').forEach((el) => {
+    el.hidden = loggedIn;
+  });
+  document.querySelectorAll('[data-auth="member"]').forEach((el) => {
+    el.hidden = !loggedIn;
+  });
+  document.querySelectorAll('[data-auth-cta]').forEach((cta) => {
+    if (!(cta instanceof HTMLElement)) return;
+    const guestText = cta.getAttribute('data-guest-text');
+    const guestHref = cta.getAttribute('data-guest-href');
+    const memberText = cta.getAttribute('data-member-text');
+    const memberHref = cta.getAttribute('data-member-href');
+    if (loggedIn) {
+      if (memberText) cta.textContent = memberText;
+      if (memberHref) cta.setAttribute('href', memberHref);
+    } else {
+      if (guestText) cta.textContent = guestText;
+      if (guestHref) cta.setAttribute('href', guestHref);
+    }
+  });
+};
+
+const showFormMessage = (form, message, type = 'error') => {
+  const messageEl = form.querySelector('[data-form-message]');
+  if (!messageEl) return;
+  messageEl.textContent = message;
+  messageEl.className = `form-message form-message--${type}`;
+  messageEl.hidden = false;
+};
+
+const clearFormMessage = (form) => {
+  const messageEl = form.querySelector('[data-form-message]');
+  if (!messageEl) return;
+  messageEl.textContent = '';
+  messageEl.hidden = true;
+};
+
+const populateMemberDashboard = () => {
+  const member = getStoredMember();
+  if (!member) return;
+
+  const name = member.name || '動能會員';
+  const sport = member.sport || '尚未設定';
+  const plan = member.plan || '一般會員';
+  const goal = member.goal || '';
+  const createdAt = member.createdAt ? new Date(member.createdAt) : new Date();
+  const today = new Date();
+  const days = Math.max(0, Math.floor((today - createdAt) / (1000 * 60 * 60 * 24)));
+
+  document.querySelectorAll('[data-member-name]').forEach((el) => {
+    el.textContent = name;
+  });
+  document.querySelectorAll('[data-member-sport]').forEach((el) => {
+    el.textContent = sport;
+  });
+  document.querySelectorAll('[data-member-plan]').forEach((el) => {
+    el.textContent = plan;
+  });
+  document.querySelectorAll('[data-member-days]').forEach((el) => {
+    el.textContent = days.toString();
+  });
+  const joinDate = document.querySelector('[data-member-join-date]');
+  if (joinDate) {
+    joinDate.textContent = createdAt.toLocaleDateString('zh-TW', { year: 'numeric', month: '2-digit', day: '2-digit' });
+  }
+  const goalEl = document.querySelector('[data-member-goal]');
+  if (goalEl) {
+    goalEl.textContent = goal ? `目前目標：${goal}` : '註冊時尚未填寫訓練目標，歡迎與教練討論設定。';
+  }
+};
+
+const registerForm = document.querySelector('[data-auth-form="register"]');
+const loginForm = document.querySelector('[data-auth-form="login"]');
+
+const currentPage = document.body?.dataset?.page || '';
+
+if (currentPage === 'member' && !isMemberLoggedIn()) {
+  window.location.href = 'login.html';
+}
+
+if ((currentPage === 'register' || currentPage === 'login') && isMemberLoggedIn()) {
+  window.location.href = 'member-home.html';
+}
+
+updateAuthUI();
+
+document.querySelectorAll('[data-action="logout"]').forEach((trigger) => {
+  trigger.addEventListener('click', (event) => {
+    event.preventDefault();
+    clearSession();
+    updateAuthUI();
+    if (document.body?.dataset?.page === 'member') {
+      window.location.href = 'login.html';
+    } else {
+      window.location.href = 'index.html';
+    }
+  });
+});
+
+if (registerForm) {
+  registerForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    clearFormMessage(registerForm);
+    const formData = new FormData(registerForm);
+    const name = (formData.get('fullName') || '').toString().trim();
+    const email = (formData.get('email') || '').toString().trim().toLowerCase();
+    const password = (formData.get('password') || '').toString();
+    const confirmPassword = (formData.get('confirmPassword') || '').toString();
+    const sport = (formData.get('sport') || '').toString();
+    const plan = (formData.get('plan') || '').toString();
+    const goal = (formData.get('goal') || '').toString().trim();
+    const agreed = formData.get('terms');
+
+    if (!name) {
+      showFormMessage(registerForm, '請輸入姓名。', 'error');
+      return;
+    }
+    if (!email) {
+      showFormMessage(registerForm, '請輸入有效的 Email。', 'error');
+      return;
+    }
+    if (password.length < 6) {
+      showFormMessage(registerForm, '密碼需至少 6 碼，包含英文與數字。', 'error');
+      return;
+    }
+    if (password !== confirmPassword) {
+      showFormMessage(registerForm, '兩次輸入的密碼不一致。', 'error');
+      return;
+    }
+    if (!sport) {
+      showFormMessage(registerForm, '請選擇主要訓練項目。', 'error');
+      return;
+    }
+    if (!plan) {
+      showFormMessage(registerForm, '請選擇偏好方案。', 'error');
+      return;
+    }
+    if (!agreed) {
+      showFormMessage(registerForm, '請勾選同意會員條款。', 'error');
+      return;
+    }
+
+    const existing = getStoredMember();
+    const createdAt = existing && existing.email === email ? existing.createdAt : new Date().toISOString();
+
+    const memberData = {
+      name,
+      email,
+      password,
+      sport,
+      plan,
+      goal,
+      createdAt,
+    };
+
+    if (!saveMember(memberData)) {
+      showFormMessage(registerForm, '儲存會員資料時發生錯誤，請稍後再試。', 'error');
+      return;
+    }
+
+    setSessionEmail(email);
+    updateAuthUI();
+    showFormMessage(registerForm, '註冊成功，正在為你前往會員中心。', 'success');
+
+    window.setTimeout(() => {
+      window.location.href = 'member-home.html';
+    }, 600);
+  });
+}
+
+if (loginForm) {
+  loginForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    clearFormMessage(loginForm);
+    const formData = new FormData(loginForm);
+    const email = (formData.get('email') || '').toString().trim().toLowerCase();
+    const password = (formData.get('password') || '').toString();
+
+    if (!email || !password) {
+      showFormMessage(loginForm, '請輸入 Email 與密碼。', 'error');
+      return;
+    }
+
+    const member = getStoredMember();
+    if (!member || member.email.toLowerCase() !== email) {
+      showFormMessage(loginForm, '找不到此帳號，請確認 Email 或先註冊會員。', 'error');
+      return;
+    }
+
+    if (member.password !== password) {
+      showFormMessage(loginForm, '密碼不正確，請再試一次。', 'error');
+      return;
+    }
+
+    setSessionEmail(member.email);
+    updateAuthUI();
+    showFormMessage(loginForm, '登入成功，立即帶你前往會員中心。', 'success');
+
+    window.setTimeout(() => {
+      window.location.href = 'member-home.html';
+    }, 400);
+  });
+}
+
+if (currentPage === 'member' && isMemberLoggedIn()) {
+  populateMemberDashboard();
+}

--- a/index.html
+++ b/index.html
@@ -44,12 +44,6 @@
             <li><a href="index.html" aria-current="page">首頁</a></li>
             <li><a href="about.html">關於我們</a></li>
             <li><a href="shop.html">商店</a></li>
-            <li><a href="#programs">訓練課程</a></li>
-            <li><a href="#sports">運動項目</a></li>
-            <li><a href="#schedule">每日行程</a></li>
-            <li><a href="#memberships">會員方案</a></li>
-            <li><a href="#news">最新消息</a></li>
-            <li><a href="#contact">聯絡我們</a></li>
             <li class="nav-auth nav-auth--guest" data-auth="guest"><a href="login.html">會員登入</a></li>
             <li class="nav-auth nav-auth--guest" data-auth="guest"><a href="register.html">加入會員</a></li>
             <li class="nav-auth nav-auth--member" data-auth="member" hidden><a href="member-home.html">會員中心</a></li>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,596 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>動能運動俱樂部｜多元運動主題首頁</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700;800&family=Rajdhani:wght@500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/base.css" />
+    <link rel="stylesheet" href="assets/css/components.css" />
+    <link rel="stylesheet" href="assets/css/home.css" />
+  </head>
+  <body>
+    <a class="skip-link" href="#main">跳至主要內容</a>
+
+    <div class="topbar" aria-label="聯絡資訊">
+      <div class="wrapper topbar__inner">
+        <div class="topbar__contact">
+          <a href="tel:+886212345678">電話 +886 2 1234 5678</a>
+          <a href="mailto:service@motionclub.tw">service@motionclub.tw</a>
+          <span>營業時間 06:00 – 22:00</span>
+        </div>
+        <ul class="social-list" aria-label="社群連結">
+          <li><a href="#">Facebook</a></li>
+          <li><a href="#">Instagram</a></li>
+          <li><a href="#">YouTube</a></li>
+        </ul>
+      </div>
+    </div>
+
+    <header class="site-header" aria-label="主要導覽">
+      <div class="wrapper site-header__inner">
+        <a class="brand" href="index.html">
+          <span class="brand__mark">MC</span>
+          <span class="brand__text">動能運動俱樂部</span>
+        </a>
+        <nav class="site-nav" aria-label="主選單">
+          <button class="site-nav__toggle" aria-expanded="false" aria-controls="primary-nav">選單</button>
+          <ul id="primary-nav" class="site-nav__list">
+            <li><a href="index.html" aria-current="page">首頁</a></li>
+            <li><a href="about.html">關於我們</a></li>
+            <li><a href="shop.html">商店</a></li>
+            <li><a href="#programs">訓練課程</a></li>
+            <li><a href="#sports">運動項目</a></li>
+            <li><a href="#schedule">每日行程</a></li>
+            <li><a href="#memberships">會員方案</a></li>
+            <li><a href="#news">最新消息</a></li>
+            <li><a href="#contact">聯絡我們</a></li>
+            <li class="nav-auth nav-auth--guest" data-auth="guest"><a href="login.html">會員登入</a></li>
+            <li class="nav-auth nav-auth--guest" data-auth="guest"><a href="register.html">加入會員</a></li>
+            <li class="nav-auth nav-auth--member" data-auth="member" hidden><a href="member-home.html">會員中心</a></li>
+            <li class="nav-auth nav-auth--member" data-auth="member" hidden>
+              <a class="nav-logout" href="#" data-action="logout">登出</a>
+            </li>
+          </ul>
+        </nav>
+        <a
+          class="btn btn--accent"
+          href="#memberships"
+          data-auth-cta
+          data-guest-text="立即加入"
+          data-guest-href="#memberships"
+          data-member-text="會員中心"
+          data-member-href="member-home.html"
+        >
+          立即加入
+        </a>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="hero" aria-label="主視覺輪播">
+        <div class="hero__slides" role="region" aria-roledescription="carousel">
+          <article class="hero-slide is-active">
+            <div class="hero-slide__media">
+              <img src="assets/images/hero-1-placeholder.svg" alt="多項運動訓練場景建議替換為 1920x1080 運動照片" />
+              <span class="image-note image-note--overlay">1920×1080 主視覺圖片位</span>
+            </div>
+            <div class="wrapper hero-slide__inner">
+              <div class="hero-slide__content">
+                <p class="eyebrow">全方位運動基地</p>
+                <h1 class="hero-slide__title">為熱血靈魂打造的旗艦運動俱樂部</h1>
+                <p class="hero-slide__text">
+                  從室內球場、戶外跑道到水療恢復中心，動能運動俱樂部提供全台最完整的多運動培訓環境，陪你突破每一次極限。
+                </p>
+                <div class="hero-slide__actions">
+                  <a class="btn btn--primary" href="#programs">探索課程</a>
+                  <a class="btn btn--ghost" href="#sports">查看場館</a>
+                </div>
+              </div>
+            </div>
+          </article>
+          <article class="hero-slide" aria-hidden="true">
+            <div class="hero-slide__media">
+              <img src="assets/images/hero-2-placeholder.svg" alt="教練帶領團隊訓練建議替換為 1920x1080 圖片" />
+              <span class="image-note image-note--overlay">1920×1080 主視覺圖片位</span>
+            </div>
+            <div class="wrapper hero-slide__inner">
+              <div class="hero-slide__content">
+                <p class="eyebrow">專屬教練團隊</p>
+                <h2 class="hero-slide__title">依照目標量身打造訓練計畫</h2>
+                <p class="hero-slide__text">
+                  菁英教練以國際競賽經驗領航，結合智慧化數據分析，給予團體與個人最佳的階段性訓練安排。
+                </p>
+                <div class="hero-slide__actions">
+                  <a class="btn btn--primary" href="#schedule">預約體驗</a>
+                  <a class="btn btn--ghost" href="#memberships">比較方案</a>
+                </div>
+              </div>
+            </div>
+          </article>
+          <article class="hero-slide" aria-hidden="true">
+            <div class="hero-slide__media">
+              <img src="assets/images/hero-3-placeholder.svg" alt="競賽場館燈光建議替換為 1920x1080 賽事照片" />
+              <span class="image-note image-note--overlay">1920×1080 主視覺圖片位</span>
+            </div>
+            <div class="wrapper hero-slide__inner">
+              <div class="hero-slide__content">
+                <p class="eyebrow">年度賽事主場</p>
+                <h2 class="hero-slide__title">加入俱樂部專屬聯賽與國際邀請賽</h2>
+                <p class="hero-slide__text">
+                  我們每季舉辦籃球、羽球、網球與鐵人三項聯賽，提供選手舞台，讓每一次出場都成為精彩故事。
+                </p>
+                <div class="hero-slide__actions">
+                  <a class="btn btn--primary" href="#news">查看賽事</a>
+                  <a class="btn btn--ghost" href="#contact">聯絡顧問</a>
+                </div>
+              </div>
+            </div>
+          </article>
+          <div class="hero__dots" role="tablist" aria-label="主視覺切換">
+            <button class="is-active" aria-label="第 1 張"></button>
+            <button aria-label="第 2 張"></button>
+            <button aria-label="第 3 張"></button>
+          </div>
+        </div>
+      </section>
+
+      <section class="partners" aria-label="合作夥伴">
+        <div class="wrapper partners__inner">
+          <ul class="partner-list">
+            <li>PowerPlay</li>
+            <li>Swift Court</li>
+            <li>AquaBalance</li>
+            <li>Elite Gear</li>
+            <li>NextGen Run</li>
+            <li>Champion Lab</li>
+          </ul>
+        </div>
+      </section>
+
+      <section id="about" class="feature-grid" aria-label="俱樂部亮點">
+        <div class="wrapper">
+          <div class="section-head">
+            <span class="eyebrow">核心優勢</span>
+            <h2 class="section-title">打造專業運動生活的四大理由</h2>
+          </div>
+          <div class="feature-grid__list">
+            <article class="feature-card">
+              <span class="feature-card__icon feature-card__icon--arena" aria-hidden="true"></span>
+              <h3>國際級多功能場館</h3>
+              <p>涵蓋籃球、羽球、網球、五人制足球及游泳池，配備國際賽事等級地坪與照明。</p>
+            </article>
+            <article class="feature-card">
+              <span class="feature-card__icon feature-card__icon--coach" aria-hidden="true"></span>
+              <h3>菁英教練專業團隊</h3>
+              <p>超過 30 位持證教練，提供一對一分析與團體課程，掌握體能與技戰術提升。</p>
+            </article>
+            <article class="feature-card">
+              <span class="feature-card__icon feature-card__icon--recovery" aria-hidden="true"></span>
+              <h3>完整恢復與營養支持</h3>
+              <p>設有運動防護室、冰熱交替池與營養諮詢吧台，讓訓練與恢復完整銜接。</p>
+            </article>
+            <article class="feature-card">
+              <span class="feature-card__icon feature-card__icon--community" aria-hidden="true"></span>
+              <h3>熱血社群與聯賽</h3>
+              <p>每月社群活動與跨項聯盟賽，串聯愛好者與選手，分享成就與動能。</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="programs" class="programs" aria-label="訓練課程">
+        <div class="wrapper">
+          <div class="section-head">
+            <span class="eyebrow">精選課程</span>
+            <h2 class="section-title">多元訓練路線，滿足不同目標</h2>
+          </div>
+          <div class="programs__grid">
+            <article class="program-card">
+              <div class="program-card__media program-card__media--tennis" aria-hidden="true"></div>
+              <div class="program-card__body">
+                <h3>網球戰術工作坊</h3>
+                <p>由前職業選手帶領進階戰術拆解與場上決策練習，結合影音回放提升臨場反應。</p>
+                <a class="program-card__link" href="#contact">預約諮詢</a>
+              </div>
+            </article>
+            <article class="program-card">
+              <div class="program-card__media program-card__media--basketball" aria-hidden="true"></div>
+              <div class="program-card__body">
+                <h3>籃球爆發力訓練</h3>
+                <p>整合力量、敏捷與跳躍能力課程，利用動態阻力與加速器材，提升禁區主宰力。</p>
+                <a class="program-card__link" href="#contact">預約諮詢</a>
+              </div>
+            </article>
+            <article class="program-card">
+              <div class="program-card__media program-card__media--swim" aria-hidden="true"></div>
+              <div class="program-card__body">
+                <h3>游泳耐力循環</h3>
+                <p>結合姿勢矯正與節奏訓練，適合鐵人三項與長距離選手建立穩定輸出。</p>
+                <a class="program-card__link" href="#contact">預約諮詢</a>
+              </div>
+            </article>
+            <article class="program-card">
+              <div class="program-card__media program-card__media--fitness" aria-hidden="true"></div>
+              <div class="program-card__body">
+                <h3>全方位體能強化</h3>
+                <p>融合體重訓練與心肺間歇，透過週期化安排打造均衡體能與核心力量。</p>
+                <a class="program-card__link" href="#contact">預約諮詢</a>
+              </div>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="sports" class="sports" aria-label="運動項目">
+        <div class="wrapper">
+          <div class="section-head section-head--center">
+            <span class="eyebrow">運動項目</span>
+            <h2 class="section-title">一次滿足你的跨項訓練需求</h2>
+          </div>
+          <div class="sports__grid">
+            <article class="sports-card">
+              <h3>網球中心</h3>
+              <p>六座室內硬地與紅土球場，搭配 Hawk-Eye 軌跡系統分析擊球表現。</p>
+            </article>
+            <article class="sports-card">
+              <h3>籃球館</h3>
+              <p>FIBA 認證木地板、LED 計分牆與 300 席觀眾席，全年舉辦聯賽與訓練營。</p>
+            </article>
+            <article class="sports-card">
+              <h3>足球訓練場</h3>
+              <p>高規格草皮與球門模組，夜間照明與戰術攝影協助分析場上走位。</p>
+            </article>
+            <article class="sports-card">
+              <h3>游泳與水療</h3>
+              <p>50 公尺標準池、SPA 恢復池與水療教室，提供技術訓練與復健課程。</p>
+            </article>
+            <article class="sports-card">
+              <h3>體適能空間</h3>
+              <p>自由重量、阻力器材與功能訓練區整合一體，支援個人與團課需求。</p>
+            </article>
+            <article class="sports-card">
+              <h3>跑步與單車</h3>
+              <p>室內跑道與智慧單車訓練室，搭配虛擬賽道，模擬各種地形挑戰。</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="stats" aria-label="成績亮點">
+        <div class="wrapper stats__inner">
+          <article class="stat">
+            <span class="stat__value">12</span>
+            <span class="stat__label">年度國際賽事主辦</span>
+          </article>
+          <article class="stat">
+            <span class="stat__value">30+</span>
+            <span class="stat__label">專任教練與體能師</span>
+          </article>
+          <article class="stat">
+            <span class="stat__value">4,500</span>
+            <span class="stat__label">活躍會員</span>
+          </article>
+          <article class="stat">
+            <span class="stat__value">98%</span>
+            <span class="stat__label">會員滿意推薦</span>
+          </article>
+        </div>
+      </section>
+
+      <section id="schedule" class="schedule" aria-label="本週時程">
+        <div class="wrapper schedule__inner">
+          <div class="section-head">
+            <span class="eyebrow">本週行程</span>
+            <h2 class="section-title">掌握每日課程與場地安排</h2>
+          </div>
+          <div class="schedule__table" role="table">
+            <div class="schedule__row schedule__row--head" role="row">
+              <span role="columnheader">時間</span>
+              <span role="columnheader">週一</span>
+              <span role="columnheader">週三</span>
+              <span role="columnheader">週五</span>
+            </div>
+            <div class="schedule__row" role="row">
+              <span role="cell">07:00</span>
+              <span role="cell">晨間功能訓練</span>
+              <span role="cell">耐力跑團練</span>
+              <span role="cell">游泳技術調整</span>
+            </div>
+            <div class="schedule__row" role="row">
+              <span role="cell">10:00</span>
+              <span role="cell">青少年網球</span>
+              <span role="cell">籃球投籃訓練</span>
+              <span role="cell">羽球雙打戰術</span>
+            </div>
+            <div class="schedule__row" role="row">
+              <span role="cell">14:00</span>
+              <span role="cell">女子足球策略課</span>
+              <span role="cell">職業選手體能</span>
+              <span role="cell">鐵人三項模擬</span>
+            </div>
+            <div class="schedule__row" role="row">
+              <span role="cell">19:00</span>
+              <span role="cell">籃球聯盟例行賽</span>
+              <span role="cell">游泳長距離課</span>
+              <span role="cell">俱樂部夜跑</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="gallery" aria-label="場館圖集">
+        <div class="wrapper">
+          <div class="section-head section-head--center">
+            <span class="eyebrow">空間搶先看</span>
+            <h2 class="section-title">沉浸式運動場域一次掌握</h2>
+          </div>
+          <div class="gallery__grid">
+            <div class="gallery__item gallery__item--court" aria-label="室內網球場" role="img"></div>
+            <div class="gallery__item gallery__item--pool" aria-label="標準游泳池" role="img"></div>
+            <div class="gallery__item gallery__item--gym" aria-label="體能訓練空間" role="img"></div>
+            <div class="gallery__item gallery__item--arena" aria-label="籃球館賽事" role="img"></div>
+            <div class="gallery__item gallery__item--soccer" aria-label="足球戰術訓練" role="img"></div>
+            <div class="gallery__item gallery__item--lounge" aria-label="會員交流空間" role="img"></div>
+          </div>
+        </div>
+      </section>
+
+      <section id="memberships" class="plans" aria-label="會員方案">
+        <div class="wrapper">
+          <div class="section-head section-head--center">
+            <span class="eyebrow">會員方案</span>
+            <h2 class="section-title">選擇適合你節奏的動能方案</h2>
+          </div>
+          <div class="plans__grid">
+            <article class="plan-card">
+              <h3>入門體驗</h3>
+              <p class="plan-card__price">$1,980<span>/月</span></p>
+              <ul>
+                <li>每週 3 堂團體課</li>
+                <li>器材使用時段預約</li>
+                <li>教練諮詢 1 次</li>
+              </ul>
+              <a class="btn btn--primary" href="#contact">開始體驗</a>
+            </article>
+            <article class="plan-card plan-card--featured">
+              <span class="plan-card__badge">人氣首選</span>
+              <h3>競賽培訓</h3>
+              <p class="plan-card__price">$3,980<span>/月</span></p>
+              <ul>
+                <li>不限次數團體課</li>
+                <li>個人訓練與體能評估</li>
+                <li>恢復中心無限使用</li>
+              </ul>
+              <a class="btn btn--accent" href="#contact">立即申請</a>
+            </article>
+            <article class="plan-card">
+              <h3>菁英聯賽</h3>
+              <p class="plan-card__price">$5,980<span>/月</span></p>
+              <ul>
+                <li>專屬私人教練</li>
+                <li>國際賽事參賽協助</li>
+                <li>品牌裝備贊助</li>
+              </ul>
+              <a class="btn btn--primary" href="#contact">洽詢顧問</a>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="coaches" class="coaches" aria-label="教練陣容">
+        <div class="wrapper">
+          <div class="section-head">
+            <span class="eyebrow">專家團隊</span>
+            <h2 class="section-title">與最懂你的教練並肩作戰</h2>
+          </div>
+          <div class="coaches__grid">
+            <article class="coach-card">
+              <div class="coach-card__avatar coach-card__avatar--tennis" aria-hidden="true"></div>
+              <div class="coach-card__body">
+                <h3>林子翔</h3>
+                <p>前國家隊網球選手，專精於戰術判讀與臨場調整。</p>
+              </div>
+            </article>
+            <article class="coach-card">
+              <div class="coach-card__avatar coach-card__avatar--basketball" aria-hidden="true"></div>
+              <div class="coach-card__body">
+                <h3>陳佳穎</h3>
+                <p>WNBA 體能教練背景，擅長爆發力與敏捷訓練設計。</p>
+              </div>
+            </article>
+            <article class="coach-card">
+              <div class="coach-card__avatar coach-card__avatar--swim" aria-hidden="true"></div>
+              <div class="coach-card__body">
+                <h3>張廷安</h3>
+                <p>游泳國際裁判暨教練，注重姿勢修正與節奏掌握。</p>
+              </div>
+            </article>
+            <article class="coach-card">
+              <div class="coach-card__avatar coach-card__avatar--soccer" aria-hidden="true"></div>
+              <div class="coach-card__body">
+                <h3>黃柏祺</h3>
+                <p>歐洲 UEFA-B 認證，專職青少年足球與戰術指導。</p>
+              </div>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="testimonials" aria-label="會員見證">
+        <div class="wrapper">
+          <div class="section-head section-head--center">
+            <span class="eyebrow">口碑分享</span>
+            <h2 class="section-title">聽聽會員如何在這裡蛻變</h2>
+          </div>
+          <div class="testimonial-slider" role="region" aria-roledescription="carousel">
+            <div class="testimonial-slider__viewport">
+              <article class="testimonial is-active">
+                <p>「加入動能運動俱樂部後，我在半年內提升了比賽穩定度，也享受團隊陪伴帶來的向心力。」</p>
+                <span class="testimonial__author">— 吳庭瑄｜網球代表隊</span>
+              </article>
+              <article class="testimonial">
+                <p>「教練團隊以數據分析提供建議，不只體能進步，恢復與飲食也更有方向。」</p>
+                <span class="testimonial__author">— 王志偉｜籃球教練</span>
+              </article>
+              <article class="testimonial">
+                <p>「俱樂部的社群活動豐富，每週都能與不同項目的夥伴交流，充滿動力。」</p>
+                <span class="testimonial__author">— 林怡君｜鐵人三項選手</span>
+              </article>
+            </div>
+            <div class="testimonial__dots" role="tablist" aria-label="見證切換">
+              <button class="is-active" aria-label="第一則"></button>
+              <button aria-label="第二則"></button>
+              <button aria-label="第三則"></button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="news" class="news" aria-label="最新消息">
+        <div class="wrapper">
+          <div class="section-head">
+            <span class="eyebrow">最新消息</span>
+            <h2 class="section-title">掌握俱樂部焦點與賽事速報</h2>
+          </div>
+          <div class="news__grid">
+            <article class="news-card">
+              <div class="news-card__media news-card__media--league" aria-hidden="true"></div>
+              <div class="news-card__body">
+                <span class="news-card__date">2024.05.02</span>
+                <h3>春季菁英聯賽總決賽點燃</h3>
+                <p>網球與籃球聯賽進入最終戰，現場設置互動體驗區，邀請會員齊聚應援。</p>
+                <a class="news-card__link" href="#">閱讀更多</a>
+              </div>
+            </article>
+            <article class="news-card">
+              <div class="news-card__media news-card__media--clinic" aria-hidden="true"></div>
+              <div class="news-card__body">
+                <span class="news-card__date">2024.04.21</span>
+                <h3>國際教練講座：恢復力學</h3>
+                <p>邀請歐美運動防護專家分享恢復流程與自我監測工具，開放會員免費參與。</p>
+                <a class="news-card__link" href="#">閱讀更多</a>
+              </div>
+            </article>
+            <article class="news-card">
+              <div class="news-card__media news-card__media--community" aria-hidden="true"></div>
+              <div class="news-card__body">
+                <span class="news-card__date">2024.04.08</span>
+                <h3>多運動體驗週報名開跑</h3>
+                <p>七天跨項體驗課程一次玩遍網球、游泳與體能訓練，新會員可享入會禮。</p>
+                <a class="news-card__link" href="#">閱讀更多</a>
+              </div>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="cta" aria-label="立即加入">
+        <div class="wrapper cta__inner">
+          <div class="cta__copy">
+            <h2>立即加入動能運動俱樂部</h2>
+            <p>無論是挑戰個人極限、準備賽事或純粹享受運動生活，這裡都有適合你的舞台。</p>
+          </div>
+          <a class="btn btn--accent" href="#contact">預約體驗</a>
+        </div>
+      </section>
+
+      <section id="contact" class="contact" aria-label="聯絡我們">
+        <div class="wrapper contact__inner">
+          <div class="contact__info">
+            <h2>聯絡資訊</h2>
+            <p>台北市信義區競技大道 88 號｜捷運藍線動能站 3 號出口</p>
+            <ul>
+              <li>電話：+886 2 1234 5678</li>
+              <li>Email：service@motionclub.tw</li>
+              <li>官方 LINE：@motionclub</li>
+            </ul>
+          </div>
+          <form class="contact__form">
+            <div class="form-group">
+              <label for="contact-name">姓名</label>
+              <input id="contact-name" name="name" type="text" placeholder="請輸入姓名" />
+            </div>
+            <div class="form-group">
+              <label for="contact-email">Email</label>
+              <input id="contact-email" name="email" type="email" placeholder="example@mail.com" />
+            </div>
+            <div class="form-group">
+              <label for="contact-topic">想了解的項目</label>
+              <select id="contact-topic" name="topic">
+                <option>網球訓練</option>
+                <option>籃球訓練</option>
+                <option>游泳訓練</option>
+                <option>體能訓練</option>
+                <option>其他需求</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label for="contact-message">留言</label>
+              <textarea id="contact-message" name="message" rows="4" placeholder="請留下需求或問題"></textarea>
+            </div>
+            <button class="btn btn--primary" type="submit">送出諮詢</button>
+          </form>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer" aria-label="頁尾">
+      <div class="wrapper site-footer__top">
+        <div class="site-footer__about">
+          <a class="brand" href="index.html">
+            <span class="brand__mark">MC</span>
+            <span class="brand__text">動能運動俱樂部</span>
+          </a>
+          <p>結合多運動項目、科技化訓練與菁英教練團隊，打造全方位的運動生活圈。</p>
+        </div>
+        <div class="site-footer__links">
+          <h3>快速連結</h3>
+          <ul>
+            <li><a href="#programs">訓練課程</a></li>
+            <li><a href="#sports">運動項目</a></li>
+            <li><a href="#memberships">會員方案</a></li>
+            <li><a href="#news">最新消息</a></li>
+            <li data-auth="guest"><a href="login.html">會員登入</a></li>
+            <li data-auth="guest"><a href="register.html">加入會員</a></li>
+          </ul>
+        </div>
+        <div class="site-footer__links">
+          <h3>更多資源</h3>
+          <ul>
+            <li><a href="about.html">關於我們</a></li>
+            <li><a href="shop.html">運動裝備商店</a></li>
+            <li><a href="#contact">預約導覽</a></li>
+            <li><a href="#">加入合作</a></li>
+            <li data-auth="member" hidden><a href="member-home.html">會員中心</a></li>
+          </ul>
+        </div>
+        <div class="site-footer__newsletter">
+          <h3>訂閱電子報</h3>
+          <form>
+            <label class="visually-hidden" for="newsletter-email">Email</label>
+            <input id="newsletter-email" type="email" placeholder="輸入 Email" />
+            <button class="btn btn--accent" type="submit">訂閱</button>
+          </form>
+        </div>
+      </div>
+      <div class="site-footer__bottom">
+        <div class="wrapper site-footer__bottom-inner">
+          <span>© 2024 動能運動俱樂部 Motion Club. All rights reserved.</span>
+          <ul class="social-list">
+            <li><a href="#">Facebook</a></li>
+            <li><a href="#">Instagram</a></li>
+            <li><a href="#">YouTube</a></li>
+          </ul>
+        </div>
+      </div>
+    </footer>
+
+    <script src="assets/js/global.js" defer></script>
+  </body>
+</html>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>會員登入｜動能運動俱樂部</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700;800&family=Rajdhani:wght@500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/base.css" />
+    <link rel="stylesheet" href="assets/css/components.css" />
+    <link rel="stylesheet" href="assets/css/auth.css" />
+  </head>
+  <body class="auth-page" data-page="login">
+    <a class="skip-link" href="#main">跳至主要內容</a>
+
+    <header class="site-header site-header--plain" aria-label="主要導覽">
+      <div class="wrapper site-header__inner">
+        <a class="brand" href="index.html">
+          <span class="brand__mark">MC</span>
+          <span class="brand__text">動能運動俱樂部</span>
+        </a>
+        <nav class="site-nav" aria-label="主選單">
+          <button class="site-nav__toggle" aria-expanded="false" aria-controls="primary-nav">選單</button>
+          <ul id="primary-nav" class="site-nav__list">
+            <li><a href="index.html">首頁</a></li>
+            <li><a href="about.html">關於我們</a></li>
+            <li><a href="shop.html">商店</a></li>
+            <li><a href="index.html#programs">訓練課程</a></li>
+            <li><a href="index.html#memberships">會員方案</a></li>
+            <li><a href="index.html#contact">聯絡我們</a></li>
+            <li class="nav-auth nav-auth--guest" data-auth="guest"><a href="login.html" aria-current="page">會員登入</a></li>
+            <li class="nav-auth nav-auth--guest" data-auth="guest"><a href="register.html">加入會員</a></li>
+            <li class="nav-auth nav-auth--member" data-auth="member" hidden><a href="member-home.html">會員中心</a></li>
+            <li class="nav-auth nav-auth--member" data-auth="member" hidden>
+              <a class="nav-logout" href="#" data-action="logout">登出</a>
+            </li>
+          </ul>
+        </nav>
+        <a
+          class="btn btn--accent"
+          href="register.html"
+          data-auth-cta
+          data-guest-text="立即加入"
+          data-guest-href="register.html"
+          data-member-text="會員中心"
+          data-member-href="member-home.html"
+        >
+          立即加入
+        </a>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="auth-hero" aria-label="會員登入">
+        <div class="wrapper auth-hero__inner">
+          <div class="auth-card">
+            <div>
+              <h2>登入會員中心</h2>
+              <p>輸入註冊時的 Email 與密碼即可管理課程與個人資料。</p>
+            </div>
+            <form data-auth-form="login" novalidate>
+              <div class="form-group">
+                <label class="field-label" for="login-email">Email</label>
+                <input id="login-email" name="email" type="email" placeholder="name@example.com" required />
+              </div>
+              <div class="form-group">
+                <label class="field-label" for="login-password">密碼</label>
+                <input id="login-password" name="password" type="password" placeholder="請輸入密碼" required />
+              </div>
+              <p class="form-note">若忘記密碼，請聯絡客服信箱 service@motionclub.tw 協助重設。</p>
+              <p class="form-message" data-form-message aria-live="polite" hidden></p>
+              <button class="btn btn--primary" type="submit">登入</button>
+            </form>
+            <div class="auth-links">
+              <span>還沒有帳號？</span>
+              <a href="register.html">立即註冊</a>
+            </div>
+          </div>
+          <div class="auth-hero__content">
+            <span class="eyebrow">會員專屬</span>
+            <h1>掌握你的訓練進度與最新活動</h1>
+            <p>
+              會員中心彙整個人課程、教練回饋、賽事資訊與商城訂單，協助你同步掌握所有運動安排。
+            </p>
+            <div class="auth-hero__meta">
+              <span>・查看個人化課程表</span>
+              <span>・追蹤訓練成效數據</span>
+              <span>・接收賽事與優惠通知</span>
+            </div>
+            <div class="auth-summary">
+              <strong>圖片建議尺寸：</strong>
+              <span>若要替換登入視覺，可使用 1200×800 px 的動態運動照片。</span>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer" aria-label="頁尾">
+      <div class="wrapper site-footer__bottom-inner">
+        <span>© 2024 動能運動俱樂部 Motion Club. All rights reserved.</span>
+        <ul class="social-list">
+          <li><a href="#">Facebook</a></li>
+          <li><a href="#">Instagram</a></li>
+          <li><a href="#">YouTube</a></li>
+        </ul>
+      </div>
+    </footer>
+
+    <script src="assets/js/global.js" defer></script>
+  </body>
+</html>

--- a/member-home.html
+++ b/member-home.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>會員中心｜動能運動俱樂部</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700;800&family=Rajdhani:wght@500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/base.css" />
+    <link rel="stylesheet" href="assets/css/components.css" />
+    <link rel="stylesheet" href="assets/css/member.css" />
+  </head>
+  <body class="page-member" data-page="member">
+    <a class="skip-link" href="#main">跳至主要內容</a>
+
+    <header class="site-header site-header--plain" aria-label="主要導覽">
+      <div class="wrapper site-header__inner">
+        <a class="brand" href="index.html">
+          <span class="brand__mark">MC</span>
+          <span class="brand__text">動能運動俱樂部</span>
+        </a>
+        <nav class="site-nav" aria-label="主選單">
+          <button class="site-nav__toggle" aria-expanded="false" aria-controls="primary-nav">選單</button>
+          <ul id="primary-nav" class="site-nav__list">
+            <li><a href="index.html">首頁</a></li>
+            <li><a href="about.html">關於我們</a></li>
+            <li><a href="shop.html">商店</a></li>
+            <li><a href="index.html#programs">訓練課程</a></li>
+            <li><a href="index.html#memberships">會員方案</a></li>
+            <li><a href="index.html#contact">聯絡我們</a></li>
+            <li class="nav-auth nav-auth--guest" data-auth="guest"><a href="login.html">會員登入</a></li>
+            <li class="nav-auth nav-auth--guest" data-auth="guest"><a href="register.html">加入會員</a></li>
+            <li class="nav-auth nav-auth--member" data-auth="member" hidden><a href="member-home.html" aria-current="page">會員中心</a></li>
+            <li class="nav-auth nav-auth--member" data-auth="member" hidden>
+              <a class="nav-logout" href="#" data-action="logout">登出</a>
+            </li>
+          </ul>
+        </nav>
+        <a
+          class="btn btn--accent"
+          href="index.html#programs"
+          data-auth-cta
+          data-guest-text="預約體驗"
+          data-guest-href="index.html#memberships"
+          data-member-text="預約課程"
+          data-member-href="index.html#schedule"
+        >
+          預約課程
+        </a>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="dashboard-hero" aria-label="會員歡迎">
+        <div class="wrapper dashboard-hero__inner">
+          <span class="eyebrow">會員中心</span>
+          <h1>歡迎回來，<span data-member-name>動能會員</span>！</h1>
+          <p>
+            這裡彙整你的課程安排、教練建議與商城優惠，讓你專注在下一次的極限突破。保持熱血，我們與你並肩前進。
+          </p>
+          <div class="dashboard-hero__meta">
+            <span>主要項目：<strong data-member-sport>尚未設定</strong></span>
+            <span>會員方案：<strong data-member-plan>一般會員</strong></span>
+            <span>加入日期：<strong data-member-join-date>--</strong></span>
+          </div>
+          <p class="dashboard-hero__goal" data-member-goal>註冊時尚未填寫訓練目標，歡迎與教練討論設定。</p>
+          <div class="dashboard-hero__actions">
+            <a class="btn btn--primary" href="index.html#schedule">查看課程表</a>
+            <a class="btn btn--ghost" href="shop.html#offers">前往網球專門店</a>
+          </div>
+        </div>
+      </section>
+
+      <section class="dashboard-section" aria-label="會員狀態">
+        <div class="wrapper">
+          <div class="dashboard-head">
+            <div>
+              <span class="eyebrow">會員總覽</span>
+              <h2 class="section-title">個人狀態摘要</h2>
+            </div>
+            <p>依據你的註冊資料產生，若需調整請聯繫教練或客服協助更新。</p>
+          </div>
+          <div class="stat-grid">
+            <article class="stat-card">
+              <h3>目前方案</h3>
+              <strong data-member-plan>一般會員</strong>
+              <p>對應於會員方案區的權益與課程折扣。</p>
+            </article>
+            <article class="stat-card">
+              <h3>主要項目</h3>
+              <strong data-member-sport>尚未設定</strong>
+              <p>教練團隊會依據此項目安排專屬訓練內容。</p>
+            </article>
+            <article class="stat-card">
+              <h3>加入天數</h3>
+              <strong><span data-member-days>0</span> 天</strong>
+              <p>從註冊日起算，定期回顧進步軌跡。</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="dashboard-section dashboard-section--alt" aria-label="快速操作">
+        <div class="wrapper">
+          <div class="dashboard-head">
+            <div>
+              <span class="eyebrow">行動捷徑</span>
+              <h2 class="section-title">立即開啟下一步訓練</h2>
+            </div>
+            <p>以下連結協助你快速預約課程、檢視教練建議與補足訓練裝備。</p>
+          </div>
+          <div class="dashboard-actions__grid">
+            <article class="action-card">
+              <h3>預約專屬教練</h3>
+              <p>與教練討論訓練目標與週期安排，制定下一階段課表。</p>
+              <a href="index.html#contact">聯絡顧問</a>
+            </article>
+            <article class="action-card">
+              <h3>檢視訓練課程</h3>
+              <p>查看跨項課程時間，選擇最符合你行程的團體或個別訓練。</p>
+              <a href="index.html#programs">探索課程</a>
+            </article>
+            <article class="action-card">
+              <h3>補齊運動裝備</h3>
+              <p>前往網球專門店挑選器材與配件，會員享有專屬折扣。</p>
+              <a href="shop.html#offers">前往商店</a>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="dashboard-section" aria-label="近期行程">
+        <div class="wrapper">
+          <div class="dashboard-head">
+            <div>
+              <span class="eyebrow">近期安排</span>
+              <h2 class="section-title">本週訓練與活動</h2>
+            </div>
+            <p>依照你的主要項目建議，以下是近期推薦參與的課程與活動。</p>
+          </div>
+          <div class="schedule-grid">
+            <article class="schedule-card">
+              <header>
+                <time datetime="2024-07-18">7/18（四）</time>
+                <h3>專項技術強化課程</h3>
+              </header>
+              <p>針對你的主要項目 <strong data-member-sport>尚未設定</strong> 進行動作拆解與實戰模擬。</p>
+              <ul>
+                <li>60 分鐘技術訓練</li>
+                <li>15 分鐘動態伸展</li>
+                <li>課後教練回饋</li>
+              </ul>
+            </article>
+            <article class="schedule-card">
+              <header>
+                <time datetime="2024-07-20">7/20（六）</time>
+                <h3>體能與恢復循環</h3>
+              </header>
+              <p>搭配恢復設備與營養建議，維持最佳比賽狀態。</p>
+              <ul>
+                <li>體能訓練 45 分鐘</li>
+                <li>冰熱交替池 20 分鐘</li>
+                <li>營養師行前諮詢</li>
+              </ul>
+            </article>
+            <article class="schedule-card">
+              <header>
+                <time datetime="2024-07-23">7/23（二）</time>
+                <h3>會員交流賽與講座</h3>
+              </header>
+              <p>與俱樂部夥伴進行友誼賽並聆聽教練分享最新戰術趨勢。</p>
+              <ul>
+                <li>社群混合賽 90 分鐘</li>
+                <li>教練戰術講座</li>
+                <li>專屬會員茶敘</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="dashboard-section dashboard-section--alt" aria-label="最新公告">
+        <div class="wrapper">
+          <div class="dashboard-head">
+            <div>
+              <span class="eyebrow">最新公告</span>
+              <h2 class="section-title">掌握俱樂部動態</h2>
+            </div>
+            <p>不錯過任何賽事資訊與會員專屬福利，持續放大你的運動效能。</p>
+          </div>
+          <div class="dashboard-updates">
+            <article class="update-card">
+              <h3>夏季會員挑戰賽報名開跑</h3>
+              <p>報名期間至 8/5 止，依主要項目分組競賽，冠軍可獲得專屬訓練套票。</p>
+            </article>
+            <article class="update-card">
+              <h3>專屬裝備升級方案</h3>
+              <p>持會員身份至網球專門店選購球拍與鞋款，可享 9 折優惠並提供免費穿線一次。</p>
+            </article>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer" aria-label="頁尾">
+      <div class="wrapper site-footer__bottom-inner">
+        <span>© 2024 動能運動俱樂部 Motion Club. All rights reserved.</span>
+        <ul class="social-list">
+          <li><a href="#">Facebook</a></li>
+          <li><a href="#">Instagram</a></li>
+          <li><a href="#">YouTube</a></li>
+        </ul>
+      </div>
+    </footer>
+
+    <script src="assets/js/global.js" defer></script>
+  </body>
+</html>

--- a/register.html
+++ b/register.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>加入會員｜動能運動俱樂部註冊</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700;800&family=Rajdhani:wght@500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/base.css" />
+    <link rel="stylesheet" href="assets/css/components.css" />
+    <link rel="stylesheet" href="assets/css/auth.css" />
+  </head>
+  <body class="auth-page" data-page="register">
+    <a class="skip-link" href="#main">跳至主要內容</a>
+
+    <header class="site-header site-header--plain" aria-label="主要導覽">
+      <div class="wrapper site-header__inner">
+        <a class="brand" href="index.html">
+          <span class="brand__mark">MC</span>
+          <span class="brand__text">動能運動俱樂部</span>
+        </a>
+        <nav class="site-nav" aria-label="主選單">
+          <button class="site-nav__toggle" aria-expanded="false" aria-controls="primary-nav">選單</button>
+          <ul id="primary-nav" class="site-nav__list">
+            <li><a href="index.html">首頁</a></li>
+            <li><a href="about.html">關於我們</a></li>
+            <li><a href="shop.html">商店</a></li>
+            <li><a href="index.html#programs">訓練課程</a></li>
+            <li><a href="index.html#memberships">會員方案</a></li>
+            <li><a href="index.html#contact">聯絡我們</a></li>
+            <li class="nav-auth nav-auth--guest" data-auth="guest"><a href="login.html">會員登入</a></li>
+            <li class="nav-auth nav-auth--guest" data-auth="guest"><a href="register.html" aria-current="page">加入會員</a></li>
+            <li class="nav-auth nav-auth--member" data-auth="member" hidden><a href="member-home.html">會員中心</a></li>
+            <li class="nav-auth nav-auth--member" data-auth="member" hidden>
+              <a class="nav-logout" href="#" data-action="logout">登出</a>
+            </li>
+          </ul>
+        </nav>
+        <a
+          class="btn btn--accent"
+          href="login.html"
+          data-auth-cta
+          data-guest-text="立即登入"
+          data-guest-href="login.html"
+          data-member-text="會員中心"
+          data-member-href="member-home.html"
+        >
+          立即登入
+        </a>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="auth-hero" aria-label="註冊會員">
+        <div class="wrapper auth-hero__inner">
+          <div class="auth-hero__content">
+            <span class="eyebrow">加入動能</span>
+            <h1>成為俱樂部會員，開啟專屬運動旅程</h1>
+            <p>
+              註冊會員後即可預約多元課程、追蹤訓練進度並享有專屬賽事與商店優惠。只需幾個步驟，立刻加入動能運動社群。
+            </p>
+            <div class="auth-hero__meta">
+              <span>・專屬教練線上諮詢</span>
+              <span>・跨項課程彈性預約</span>
+              <span>・商城消費回饋 5%</span>
+            </div>
+            <div class="auth-summary">
+              <strong>圖片建議尺寸：</strong>
+              <span>若要更換為運動照片，建議使用 1200×800 px，JPG 或 PNG 格式。</span>
+            </div>
+          </div>
+          <div class="auth-card">
+            <div>
+              <h2>建立會員帳號</h2>
+              <p>完成註冊後即可登入會員中心管理課程與個人資料。</p>
+            </div>
+            <form data-auth-form="register" novalidate>
+              <div class="form-row">
+                <div class="form-group">
+                  <label class="field-label" for="register-name">姓名</label>
+                  <input id="register-name" name="fullName" type="text" placeholder="請輸入中文或英文姓名" required />
+                </div>
+                <div class="form-group">
+                  <label class="field-label" for="register-email">Email</label>
+                  <input id="register-email" name="email" type="email" placeholder="name@example.com" required />
+                </div>
+              </div>
+              <div class="form-row">
+                <div class="form-group">
+                  <label class="field-label" for="register-password">設定密碼</label>
+                  <input
+                    id="register-password"
+                    name="password"
+                    type="password"
+                    placeholder="至少 6 碼，包含英文與數字"
+                    minlength="6"
+                    required
+                  />
+                </div>
+                <div class="form-group">
+                  <label class="field-label" for="register-confirm">確認密碼</label>
+                  <input
+                    id="register-confirm"
+                    name="confirmPassword"
+                    type="password"
+                    placeholder="請再次輸入密碼"
+                    minlength="6"
+                    required
+                  />
+                </div>
+              </div>
+              <div class="form-row">
+                <div class="form-group">
+                  <label class="field-label" for="register-sport">主要訓練項目</label>
+                  <select id="register-sport" name="sport" required>
+                    <option value="">請選擇</option>
+                    <option value="網球">網球</option>
+                    <option value="籃球">籃球</option>
+                    <option value="羽球">羽球</option>
+                    <option value="游泳">游泳</option>
+                    <option value="體能訓練">體能訓練</option>
+                  </select>
+                </div>
+                <div class="form-group">
+                  <label class="field-label" for="register-plan">偏好方案</label>
+                  <select id="register-plan" name="plan" required>
+                    <option value="">請選擇</option>
+                    <option value="月繳制">月繳制</option>
+                    <option value="季度制">季度制</option>
+                    <option value="年繳制">年繳制</option>
+                  </select>
+                </div>
+              </div>
+              <div class="form-group">
+                <label class="field-label" for="register-goal">訓練目標（選填）</label>
+                <textarea id="register-goal" name="goal" rows="3" placeholder="如：提升發球速度、備戰鐵人三項等"></textarea>
+              </div>
+              <div class="form-group">
+                <label class="field-checkbox" for="register-terms">
+                  <input id="register-terms" name="terms" type="checkbox" value="agree" required />
+                  <span>我已閱讀並同意俱樂部會員條款與個資保護政策。</span>
+                </label>
+              </div>
+              <p class="form-note">註冊資料可於會員中心再次編輯與更新。</p>
+              <p class="form-message" data-form-message aria-live="polite" hidden></p>
+              <button class="btn btn--primary" type="submit">完成註冊</button>
+            </form>
+            <div class="auth-links">
+              <span>已經有帳號？</span>
+              <a href="login.html">立即登入</a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="auth-benefits" aria-label="會員專屬服務">
+        <div class="wrapper auth-benefits__inner">
+          <div class="section-head">
+            <span class="eyebrow">會員服務</span>
+            <h2 class="section-title">註冊後即可解鎖的三大特權</h2>
+          </div>
+          <div class="benefits-grid">
+            <article class="benefit-card">
+              <h3>個人化訓練計畫</h3>
+              <p>依據你的運動目標與週期，教練團隊將為你建立週週更新的訓練藍圖。</p>
+            </article>
+            <article class="benefit-card">
+              <h3>場館與課程快速預約</h3>
+              <p>透過會員中心即可預約跨項課程、場地與恢復設備，並查看即時候補狀態。</p>
+            </article>
+            <article class="benefit-card">
+              <h3>商城與賽事優先權</h3>
+              <p>會員享有專屬折扣、贈品兌換與俱樂部聯賽優先報名資格，精彩活動不錯過。</p>
+            </article>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer" aria-label="頁尾">
+      <div class="wrapper site-footer__bottom-inner">
+        <span>© 2024 動能運動俱樂部 Motion Club. All rights reserved.</span>
+        <ul class="social-list">
+          <li><a href="#">Facebook</a></li>
+          <li><a href="#">Instagram</a></li>
+          <li><a href="#">YouTube</a></li>
+        </ul>
+      </div>
+    </footer>
+
+    <script src="assets/js/global.js" defer></script>
+  </body>
+</html>

--- a/shop.html
+++ b/shop.html
@@ -1,0 +1,369 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>動能網球專門店｜裝備與優惠</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700;800&family=Rajdhani:wght@500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/base.css" />
+    <link rel="stylesheet" href="assets/css/components.css" />
+    <link rel="stylesheet" href="assets/css/shop.css" />
+  </head>
+  <body class="page-shop">
+    <a class="skip-link" href="#main">跳至主要內容</a>
+
+    <header class="site-header site-header--plain" aria-label="主要導覽">
+      <div class="wrapper site-header__inner">
+        <a class="brand" href="index.html">
+          <span class="brand__mark">MC</span>
+          <span class="brand__text">動能運動俱樂部</span>
+        </a>
+        <nav class="site-nav" aria-label="主選單">
+          <button class="site-nav__toggle" aria-expanded="false" aria-controls="primary-nav">選單</button>
+          <ul id="primary-nav" class="site-nav__list">
+            <li><a href="index.html">首頁</a></li>
+            <li><a href="about.html">關於我們</a></li>
+            <li><a href="shop.html" aria-current="page">商店</a></li>
+            <li><a href="index.html#sports">運動項目</a></li>
+            <li><a href="index.html#memberships">會員方案</a></li>
+            <li><a href="index.html#contact">聯絡我們</a></li>
+            <li class="nav-auth nav-auth--guest" data-auth="guest"><a href="login.html">會員登入</a></li>
+            <li class="nav-auth nav-auth--guest" data-auth="guest"><a href="register.html">加入會員</a></li>
+            <li class="nav-auth nav-auth--member" data-auth="member" hidden><a href="member-home.html">會員中心</a></li>
+            <li class="nav-auth nav-auth--member" data-auth="member" hidden>
+              <a class="nav-logout" href="#" data-action="logout">登出</a>
+            </li>
+          </ul>
+        </nav>
+        <a
+          class="btn btn--accent"
+          href="#offers"
+          data-auth-cta
+          data-guest-text="立即選購"
+          data-guest-href="#offers"
+          data-member-text="會員中心"
+          data-member-href="member-home.html"
+        >
+          立即選購
+        </a>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="hero hero--shop" aria-label="商店主視覺輪播">
+        <div class="hero__slides" role="region" aria-roledescription="carousel">
+          <article class="hero-slide is-active">
+            <div class="hero-slide__media">
+              <img src="assets/images/shop-hero-1.svg" alt="網球拍與球場建議替換為 1600x900 網球產品照片" />
+              <span class="image-note image-note--overlay">1600×900 主視覺圖片位</span>
+            </div>
+            <div class="wrapper hero-slide__inner">
+              <div class="hero-slide__content">
+                <span class="eyebrow">Tennis Flagship</span>
+                <h1>動能網球專門店</h1>
+                <p>
+                  精選國際網球品牌最新拍款、服飾與配件，提供球友專業選物、穿線服務與會員限定優惠。
+                </p>
+                <div class="hero-slide__actions">
+                  <a class="btn btn--primary" href="#categories">探索分類</a>
+                  <a class="btn btn--ghost" href="#offers">查看優惠</a>
+                </div>
+              </div>
+            </div>
+          </article>
+          <article class="hero-slide" aria-hidden="true">
+            <div class="hero-slide__media">
+              <img src="assets/images/shop-hero-2.svg" alt="網球品牌牆建議替換為 1600x900 品牌展示照片" />
+              <span class="image-note image-note--overlay">1600×900 主視覺圖片位</span>
+            </div>
+            <div class="wrapper hero-slide__inner">
+              <div class="hero-slide__content">
+                <span class="eyebrow">Premium Brands</span>
+                <h2>全球人氣網球品牌一次到位</h2>
+                <p>
+                  HEAD、Wilson、Babolat、Yonex 等旗艦系列同步引進，維持與國際巡迴相同的裝備體驗。
+                </p>
+                <div class="hero-slide__actions">
+                  <a class="btn btn--primary" href="#offers">人氣推薦</a>
+                  <a class="btn btn--ghost" href="#service">門市服務</a>
+                </div>
+              </div>
+            </div>
+          </article>
+          <article class="hero-slide" aria-hidden="true">
+            <div class="hero-slide__media">
+              <img src="assets/images/shop-hero-3.svg" alt="網球賽事氛圍建議替換為 1600x900 比賽照片" />
+              <span class="image-note image-note--overlay">1600×900 主視覺圖片位</span>
+            </div>
+            <div class="wrapper hero-slide__inner">
+              <div class="hero-slide__content">
+                <span class="eyebrow">Match Ready</span>
+                <h2>從訓練到比賽的全方位配備</h2>
+                <p>
+                  專業穿線、球拍調校與行動穿梭車到府服務，協助球友以最佳狀態踏上球場。
+                </p>
+                <div class="hero-slide__actions">
+                  <a class="btn btn--primary" href="#promos">限時活動</a>
+                  <a class="btn btn--ghost" href="index.html#contact">聯絡顧問</a>
+                </div>
+              </div>
+            </div>
+          </article>
+          <div class="hero__dots" role="tablist" aria-label="商店主視覺切換">
+            <button class="is-active" aria-label="第 1 張"></button>
+            <button aria-label="第 2 張"></button>
+            <button aria-label="第 3 張"></button>
+          </div>
+        </div>
+      </section>
+
+      <section class="usp" aria-label="服務優勢">
+        <div class="wrapper usp__grid">
+          <article class="usp-card">
+            <h2>正品保證</h2>
+            <p>全品項與原廠同步，支援國際保固與專業售後服務。</p>
+          </article>
+          <article class="usp-card">
+            <h2>專業穿線</h2>
+            <p>國際認證穿線師駐店，依照打法提供線種與磅數建議。</p>
+          </article>
+          <article class="usp-card">
+            <h2>會員獨享</h2>
+            <p>加入俱樂部即享購物金回饋、新品預購與賽事禮遇。</p>
+          </article>
+        </div>
+      </section>
+
+      <section id="categories" class="categories" aria-label="熱門分類">
+        <div class="wrapper">
+          <div class="section-head">
+            <span class="eyebrow">熱門分類</span>
+            <h2 class="section-title">依照需求快速找到裝備</h2>
+          </div>
+          <div class="categories__grid">
+            <article class="category-card">
+              <div class="category-card__media category-card__media--racket" aria-hidden="true">
+                <span class="image-note image-note--overlay">520×360 網球拍圖片位</span>
+              </div>
+              <div class="category-card__body">
+                <h3>網球拍</h3>
+                <p>Head、Wilson、Babolat 等最新中階與競賽拍款。</p>
+              </div>
+            </article>
+            <article class="category-card">
+              <div class="category-card__media category-card__media--shoe" aria-hidden="true">
+                <span class="image-note image-note--overlay">520×360 網球鞋圖片位</span>
+              </div>
+              <div class="category-card__body">
+                <h3>球鞋</h3>
+                <p>全地形支援與輕量款式兼具，含草地、紅土專用鞋。</p>
+              </div>
+            </article>
+            <article class="category-card">
+              <div class="category-card__media category-card__media--apparel" aria-hidden="true">
+                <span class="image-note image-note--overlay">520×360 服飾圖片位</span>
+              </div>
+              <div class="category-card__body">
+                <h3>服飾</h3>
+                <p>透氣吸濕與防曬系列，打造體面與舒適兼具的球場造型。</p>
+              </div>
+            </article>
+            <article class="category-card">
+              <div class="category-card__media category-card__media--gear" aria-hidden="true">
+                <span class="image-note image-note--overlay">520×360 配件圖片位</span>
+              </div>
+              <div class="category-card__body">
+                <h3>配件</h3>
+                <p>穿線、握把、球袋與智能感測器，全面升級你的裝備。</p>
+              </div>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="offers" class="featured" aria-label="精選優惠">
+        <div class="wrapper">
+          <div class="featured__header">
+            <header class="featured__intro">
+              <div class="featured__title-bar">
+                <span class="eyebrow">限時精選</span>
+                <h2 class="section-title">熱銷裝備一次入手</h2>
+              </div>
+              <p>明星推薦，球友一致好評的必備裝備，未來可替換 480×360 商品照片展示細節。</p>
+            </header>
+            <article class="bundle-card featured__highlight">
+              <figure class="bundle-card__media">
+                <img src="assets/images/products/feature-combo.svg" alt="建議替換為 960×600 網球裝備橫幅照片" />
+                <figcaption class="image-note image-note--overlay">960×600 套裝橫幅圖片位</figcaption>
+              </figure>
+              <div class="bundle-card__content">
+                <header class="bundle-card__header">
+                  <span class="eyebrow">套裝首選</span>
+                  <h3>HEAD Speed Pro 競賽套組</h3>
+                  <p>
+                    完整搭配球拍、鞋款與球袋，針對高強度巡迴賽程打造，購買即享免費穿線與教練諮詢。
+                  </p>
+                </header>
+                <div class="bundle-card__includes">
+                  <h4>套組內容</h4>
+                  <ul class="bundle-card__list">
+                    <li>Speed Pro 競賽拍 ×2（含穿線）</li>
+                    <li>Jet Mach 3 球鞋 ×1（男女款尺寸齊全）</li>
+                    <li>Tour Team 12R Monstercombi 專業球袋</li>
+                  </ul>
+                </div>
+                <footer class="bundle-card__footer">
+                  <span class="bundle-card__price">NT$15,800</span>
+                  <a class="btn btn--ghost" href="#">查看套組詳情</a>
+                </footer>
+              </div>
+            </article>
+          </div>
+          <div class="featured-grid">
+            <article class="product-card">
+              <figure class="product-card__media">
+                <img src="assets/images/products/racket-pro.svg" alt="建議替換為 480×360 職業等級網球拍照片" />
+                <figcaption class="image-note image-note--overlay">480×360 商品圖片位</figcaption>
+              </figure>
+              <div class="product-card__body">
+                <h3>Wilson Pro Staff X</h3>
+                <p>全新拍面平衡與碳纖結構強化，提供菁英球員精準擊球手感。</p>
+                <div class="product-card__meta">
+                  <span class="product-card__price">NT$8,900</span>
+                  <a class="btn btn--ghost" href="#">加入購物車</a>
+                </div>
+              </div>
+            </article>
+            <article class="product-card">
+              <figure class="product-card__media">
+                <img src="assets/images/products/shoe-speed.svg" alt="建議替換為 480×360 網球鞋產品照" />
+                <figcaption class="image-note image-note--overlay">480×360 商品圖片位</figcaption>
+              </figure>
+              <div class="product-card__body">
+                <h3>ASICS Court FF 3</h3>
+                <p>強化側向穩定與回彈避震，適合高強度移動的競賽球員。</p>
+                <div class="product-card__meta">
+                  <span class="product-card__price">NT$5,280</span>
+                  <a class="btn btn--ghost" href="#">加入購物車</a>
+                </div>
+              </div>
+            </article>
+            <article class="product-card">
+              <figure class="product-card__media">
+                <img src="assets/images/products/apparel-set.svg" alt="建議替換為 480×360 網球服飾產品照" />
+                <figcaption class="image-note image-note--overlay">480×360 商品圖片位</figcaption>
+              </figure>
+              <div class="product-card__body">
+                <h3>Nike Advantage 套裝</h3>
+                <p>採用 Dri-FIT 材質排汗透氣，維持賽場上的清爽舒適。</p>
+                <div class="product-card__meta">
+                  <span class="product-card__price">NT$3,680</span>
+                  <a class="btn btn--ghost" href="#">加入購物車</a>
+                </div>
+              </div>
+            </article>
+            <article class="product-card">
+              <figure class="product-card__media">
+                <img src="assets/images/products/bag-team.svg" alt="建議替換為 480×360 網球球袋產品照" />
+                <figcaption class="image-note image-note--overlay">480×360 商品圖片位</figcaption>
+              </figure>
+              <div class="product-card__body">
+                <h3>Babolat Team 12R 球袋</h3>
+                <p>多隔層保護設計容納球拍與裝備，附加保冷隔層適合巡迴賽使用。</p>
+                <div class="product-card__meta">
+                  <span class="product-card__price">NT$3,280</span>
+                  <a class="btn btn--ghost" href="#">加入購物車</a>
+                </div>
+              </div>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="promos" class="promos" aria-label="促銷活動">
+        <div class="wrapper promos__grid">
+          <article class="promo-card promo-card--orange">
+            <span class="eyebrow">季中折扣</span>
+            <h2>球拍滿額再九折</h2>
+            <p>單筆滿 $12,000 再享 10% 優惠，會員加碼贈專屬穿線服務。</p>
+            <a class="btn btn--ghost" href="#">搶先入手</a>
+          </article>
+          <article class="promo-card promo-card--blue">
+            <span class="eyebrow">新品上架</span>
+            <h2>專業穿線套餐 8 折</h2>
+            <p>購買指定線種即享穿線折扣，並提供個人化磅數分析。</p>
+            <a class="btn btn--ghost" href="#">立即預約</a>
+          </article>
+        </div>
+      </section>
+
+      <section class="brands" aria-label="合作品牌">
+        <div class="wrapper brands__inner">
+          <h2 class="visually-hidden">品牌列表</h2>
+          <ul class="brand-strip">
+            <li>HEAD</li>
+            <li>WILSON</li>
+            <li>BABOLAT</li>
+            <li>YONEX</li>
+            <li>ASICS</li>
+            <li>NIKE</li>
+            <li>ADIDAS</li>
+          </ul>
+        </div>
+      </section>
+
+      <section id="service" class="service" aria-label="門市服務">
+        <div class="wrapper service__inner">
+          <div class="service__media" role="img" aria-label="門市服務示意">
+            <span class="image-note image-note--overlay">720×640 門市服務圖片位</span>
+          </div>
+          <div class="service__content">
+            <span class="eyebrow">專屬門市</span>
+            <h2>旗艦店專人諮詢與體驗</h2>
+            <p>
+              位於動能運動俱樂部一樓的網球專門店提供球拍試打、腳型分析與穿線保養，歡迎預約專人顧問。
+            </p>
+            <ul>
+              <li>球拍與鞋款試用體驗</li>
+              <li>客製化穿線與握把服務</li>
+              <li>會員專屬比賽報名窗口</li>
+            </ul>
+            <a class="btn btn--primary" href="index.html#contact">預約門市</a>
+          </div>
+        </div>
+      </section>
+
+      <section class="newsletter" aria-label="訂閱優惠">
+        <div class="wrapper newsletter__inner">
+          <div class="newsletter__copy">
+            <h2>訂閱網球快訊</h2>
+            <p>掌握新品上市、賽事資訊與專屬優惠，精彩內容每週送達。</p>
+          </div>
+          <form class="newsletter__form">
+            <label class="visually-hidden" for="shop-email">Email</label>
+            <input id="shop-email" type="email" placeholder="輸入 Email" />
+            <button class="btn btn--accent" type="submit">立即訂閱</button>
+          </form>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer" aria-label="頁尾">
+      <div class="wrapper site-footer__bottom-inner">
+        <span>© 2024 動能運動俱樂部 Motion Club. All rights reserved.</span>
+        <ul class="social-list">
+          <li><a href="#">Facebook</a></li>
+          <li><a href="#">Instagram</a></li>
+          <li><a href="#">YouTube</a></li>
+        </ul>
+      </div>
+    </footer>
+
+    <script src="assets/js/global.js" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add dedicated register, login, and member home pages with localized copy, reusable auth styles, and membership imagery notes
- wire up client-side storage helpers to handle registration, login, logout, and dashboard personalization while toggling navigation/footer states
- update existing navigation CTAs and shared form styles so membership links and forms stay consistent across the site

## Testing
- not run (static site project)

------
https://chatgpt.com/codex/tasks/task_e_68db39b43b58832caa15e4247fa48ce8