### PR TITLE
Improve mobile navigation drawer accessibility

### DIFF
--- a/about.html
+++ b/about.html
@@ -25,14 +25,20 @@
         </a>
         <nav class="site-nav" aria-label="主選單">
           <button class="site-nav__toggle" aria-expanded="false" aria-controls="primary-nav">選單</button>
-          <ul id="primary-nav" class="site-nav__list">
-            <li><a href="index.html">首頁</a></li>
-            <li><a href="about.html" aria-current="page">關於我們</a></li>
-            <li><a href="shop.html">商店</a></li>
-            <li><a href="index.html#programs">訓練課程</a></li>
-            <li><a href="index.html#memberships">會員方案</a></li>
-            <li><a href="index.html#contact">聯絡我們</a></li>
-          </ul>
+          <div class="site-nav__overlay" tabindex="-1"></div>
+          <div class="site-nav__drawer" aria-hidden="true">
+            <div class="site-nav__panel">
+              <button class="site-nav__close" type="button" aria-label="關閉選單">關閉</button>
+              <ul id="primary-nav" class="site-nav__list">
+                <li><a href="index.html">首頁</a></li>
+                <li><a href="about.html" aria-current="page">關於我們</a></li>
+                <li><a href="shop.html">商店</a></li>
+                <li><a href="index.html#programs">訓練課程</a></li>
+                <li><a href="index.html#memberships">會員方案</a></li>
+                <li><a href="index.html#contact">聯絡我們</a></li>
+              </ul>
+            </div>
+          </div>
         </nav>
         <a class="btn btn--accent" href="index.html#memberships">立即加入</a>
       </div>

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -46,6 +46,10 @@
   border-bottom: 1px solid rgba(148, 163, 184, 0.18);
 }
 
+body.is-locked {
+  overflow: hidden;
+}
+
 .site-header__inner {
   display: flex;
   align-items: center;
@@ -76,6 +80,7 @@
 
 .site-nav {
   margin-left: auto;
+  position: relative;
 }
 
 .site-nav__toggle {
@@ -87,6 +92,28 @@
   border-radius: 999px;
   font-weight: 600;
   letter-spacing: 0.08em;
+}
+
+.site-nav__overlay {
+  display: none;
+}
+
+.site-nav__drawer {
+  display: contents;
+}
+
+.site-nav__panel {
+  display: contents;
+}
+
+.site-nav__close {
+  display: none;
+}
+
+.site-nav__close:hover,
+.site-nav__close:focus {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
 }
 
 .site-nav__list {
@@ -110,6 +137,42 @@
 .site-nav__list a:hover,
 .site-nav__list a:focus {
   color: var(--color-accent);
+}
+
+.site-nav__submenu {
+  list-style: none;
+  padding: 0;
+  margin: 8px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.site-nav__submenu[hidden] {
+  display: none;
+}
+
+.site-nav__submenu a {
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+  text-transform: none;
+  padding: 6px 0;
+}
+
+.site-nav__submenu-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  gap: 12px;
+  background: transparent;
+  color: inherit;
+  border: none;
+  font: inherit;
+  text-transform: inherit;
+  letter-spacing: inherit;
+  padding: 8px 0;
+  cursor: pointer;
 }
 
 .btn {
@@ -262,29 +325,100 @@
     display: inline-flex;
   }
 
-  .site-nav__list {
-    position: absolute;
-    inset: 72px 16px auto;
-    flex-direction: column;
-    background: rgba(6, 11, 26, 0.96);
-    padding: 20px;
-    border-radius: var(--radius-md);
-    box-shadow: var(--shadow-soft);
-    transform-origin: top right;
-    transform: scale(0.9);
+  .site-nav__overlay {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.65);
     opacity: 0;
     pointer-events: none;
-    transition: opacity 0.2s ease, transform 0.2s ease;
+    transition: opacity 0.25s ease;
+    z-index: 50;
   }
 
-  .site-nav__list.is-open {
+  .site-nav__overlay.is-open {
     opacity: 1;
     pointer-events: auto;
-    transform: scale(1);
+  }
+
+  .site-nav__drawer {
+    display: flex;
+    flex-direction: column;
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: auto;
+    width: min(420px, 100%);
+    padding: 88px 24px 32px;
+    gap: 24px;
+    background: rgba(6, 11, 26, 0.96);
+    backdrop-filter: blur(18px);
+    box-shadow: var(--shadow-soft);
+    transform: translateY(-12px);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.25s ease, transform 0.25s ease;
+    z-index: 60;
+  }
+
+  .site-nav__drawer.is-open {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  .site-nav__panel {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    height: 100%;
+  }
+
+  .site-nav__close {
+    display: inline-flex;
+    align-self: flex-end;
+    background: transparent;
+    color: #fff;
+    border: 1px solid rgba(148, 163, 184, 0.45);
+    padding: 8px 18px;
+    border-radius: 999px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .site-nav__list {
+    flex: 1;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 20px;
+    width: 100%;
+    overflow-y: auto;
   }
 
   .site-nav__list li {
     width: 100%;
-    text-align: center;
+    text-align: left;
+  }
+
+  .site-nav__list a {
+    width: 100%;
+    padding: 12px 0;
+  }
+
+  .site-nav__item--has-submenu {
+    width: 100%;
+  }
+
+  .site-nav__item--has-submenu.is-expanded > .site-nav__submenu-toggle {
+    color: var(--color-accent);
+  }
+
+  .site-nav__submenu {
+    width: 100%;
+    padding-left: 16px;
+    border-left: 1px solid rgba(148, 163, 184, 0.25);
+    gap: 12px;
   }
 }

--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -1,11 +1,157 @@
 const navToggle = document.querySelector('.site-nav__toggle');
+const navDrawer = document.querySelector('.site-nav__drawer');
 const navList = document.querySelector('.site-nav__list');
+const navOverlay = document.querySelector('.site-nav__overlay');
+const navClose = document.querySelector('.site-nav__close');
 
-if (navToggle && navList) {
+const focusableSelector =
+  'a[href]:not([tabindex="-1"]), button:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+let navIsOpen = false;
+let lastFocusedElement = null;
+let lastTabDirection = 'forward';
+
+function getFocusableElements() {
+  if (!navDrawer) return [];
+  const elements = Array.from(navDrawer.querySelectorAll(focusableSelector));
+  return elements.filter(
+    (element) => !element.hasAttribute('hidden') && element.getClientRects().length > 0
+  );
+}
+
+function setNavState(open) {
+  if (!navToggle || !navDrawer || !navList) return;
+
+  navIsOpen = open;
+  navToggle.setAttribute('aria-expanded', open.toString());
+  navDrawer.classList.toggle('is-open', open);
+  navDrawer.setAttribute('aria-hidden', (!open).toString());
+  navList.classList.toggle('is-open', open);
+
+  if (navOverlay) {
+    navOverlay.classList.toggle('is-open', open);
+    navOverlay.setAttribute('tabindex', open ? '0' : '-1');
+  }
+
+  if (navClose) {
+    navClose.setAttribute('tabindex', open ? '0' : '-1');
+  }
+
+  document.body.classList.toggle('is-locked', open);
+
+  if (open) {
+    lastFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    const focusable = getFocusableElements();
+    if (focusable.length) {
+      focusable[0].focus();
+    }
+    document.addEventListener('keydown', handleKeydown);
+  } else {
+    document.removeEventListener('keydown', handleKeydown);
+    if (lastFocusedElement instanceof HTMLElement) {
+      lastFocusedElement.focus();
+    } else if (navToggle) {
+      navToggle.focus();
+    }
+    lastFocusedElement = null;
+    lastTabDirection = 'forward';
+  }
+}
+
+function handleKeydown(event) {
+  if (!navIsOpen) return;
+
+  if (event.key === 'Tab') {
+    const focusable = getFocusableElements();
+    if (!focusable.length) return;
+
+    lastTabDirection = event.shiftKey ? 'backward' : 'forward';
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  } else if (event.key === 'Escape') {
+    event.preventDefault();
+    setNavState(false);
+  }
+}
+
+if (navToggle && navList && navDrawer) {
+  if (navClose) {
+    navClose.setAttribute('tabindex', '-1');
+  }
+
+  if (navOverlay) {
+    navOverlay.setAttribute('tabindex', '-1');
+  }
+
   navToggle.addEventListener('click', () => {
-    const expanded = navToggle.getAttribute('aria-expanded') === 'true';
-    navToggle.setAttribute('aria-expanded', (!expanded).toString());
-    navList.classList.toggle('is-open');
+    setNavState(!navIsOpen);
+  });
+
+  if (navClose) {
+    navClose.addEventListener('click', () => {
+      setNavState(false);
+    });
+  }
+
+  if (navOverlay) {
+    navOverlay.addEventListener('click', () => {
+      setNavState(false);
+    });
+
+    navOverlay.addEventListener('focus', () => {
+      if (!navIsOpen) return;
+      const focusable = getFocusableElements();
+      if (!focusable.length) return;
+
+      if (lastTabDirection === 'backward') {
+        focusable[focusable.length - 1].focus();
+      } else {
+        focusable[0].focus();
+      }
+    });
+  }
+
+  navList.addEventListener('click', (event) => {
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+    const link = target.closest('a');
+    if (link && navIsOpen) {
+      setNavState(false);
+    }
+  });
+
+  const submenuToggles = navList.querySelectorAll('.site-nav__submenu-toggle');
+  submenuToggles.forEach((toggle) => {
+    if (!(toggle instanceof HTMLElement)) return;
+    const controls = toggle.getAttribute('aria-controls');
+    const submenu = controls ? document.getElementById(controls) : null;
+    const parentItem = toggle.closest('li');
+
+    if (!submenu) return;
+
+    const expanded = toggle.getAttribute('aria-expanded') === 'true';
+    submenu.hidden = !expanded;
+    if (parentItem) {
+      parentItem.classList.toggle('is-expanded', expanded);
+    }
+
+    toggle.addEventListener('click', () => {
+      const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
+      const nextState = !isExpanded;
+      toggle.setAttribute('aria-expanded', nextState.toString());
+      submenu.hidden = !nextState;
+      if (parentItem) {
+        parentItem.classList.toggle('is-expanded', nextState);
+      }
+    });
   });
 }
 

--- a/index.html
+++ b/index.html
@@ -40,17 +40,23 @@
         </a>
         <nav class="site-nav" aria-label="主選單">
           <button class="site-nav__toggle" aria-expanded="false" aria-controls="primary-nav">選單</button>
-          <ul id="primary-nav" class="site-nav__list">
-            <li><a href="index.html">首頁</a></li>
-            <li><a href="about.html">關於我們</a></li>
-            <li><a href="shop.html">商店</a></li>
-            <li><a href="#programs">訓練課程</a></li>
-            <li><a href="#sports">運動項目</a></li>
-            <li><a href="#schedule">每日行程</a></li>
-            <li><a href="#memberships">會員方案</a></li>
-            <li><a href="#news">最新消息</a></li>
-            <li><a href="#contact">聯絡我們</a></li>
-          </ul>
+          <div class="site-nav__overlay" tabindex="-1"></div>
+          <div class="site-nav__drawer" aria-hidden="true">
+            <div class="site-nav__panel">
+              <button class="site-nav__close" type="button" aria-label="關閉選單">關閉</button>
+              <ul id="primary-nav" class="site-nav__list">
+                <li><a href="index.html">首頁</a></li>
+                <li><a href="about.html">關於我們</a></li>
+                <li><a href="shop.html">商店</a></li>
+                <li><a href="#programs">訓練課程</a></li>
+                <li><a href="#sports">運動項目</a></li>
+                <li><a href="#schedule">每日行程</a></li>
+                <li><a href="#memberships">會員方案</a></li>
+                <li><a href="#news">最新消息</a></li>
+                <li><a href="#contact">聯絡我們</a></li>
+              </ul>
+            </div>
+          </div>
         </nav>
         <a class="btn btn--accent" href="#memberships">立即加入</a>
       </div>

--- a/shop.html
+++ b/shop.html
@@ -25,14 +25,20 @@
         </a>
         <nav class="site-nav" aria-label="主選單">
           <button class="site-nav__toggle" aria-expanded="false" aria-controls="primary-nav">選單</button>
-          <ul id="primary-nav" class="site-nav__list">
-            <li><a href="index.html">首頁</a></li>
-            <li><a href="about.html">關於我們</a></li>
-            <li><a href="shop.html" aria-current="page">商店</a></li>
-            <li><a href="index.html#sports">運動項目</a></li>
-            <li><a href="index.html#memberships">會員方案</a></li>
-            <li><a href="index.html#contact">聯絡我們</a></li>
-          </ul>
+          <div class="site-nav__overlay" tabindex="-1"></div>
+          <div class="site-nav__drawer" aria-hidden="true">
+            <div class="site-nav__panel">
+              <button class="site-nav__close" type="button" aria-label="關閉選單">關閉</button>
+              <ul id="primary-nav" class="site-nav__list">
+                <li><a href="index.html">首頁</a></li>
+                <li><a href="about.html">關於我們</a></li>
+                <li><a href="shop.html" aria-current="page">商店</a></li>
+                <li><a href="index.html#sports">運動項目</a></li>
+                <li><a href="index.html#memberships">會員方案</a></li>
+                <li><a href="index.html#contact">聯絡我們</a></li>
+              </ul>
+            </div>
+          </div>
         </nav>
         <a class="btn btn--accent" href="#offers">立即選購</a>
       </div>


### PR DESCRIPTION
## Summary
- add navigation overlay, drawer panel, and close button markup across the main site templates
- implement responsive styling for the full-screen mobile drawer, backdrop, and accordion-ready submenus while locking body scroll when open
- enhance global navigation script with focus trapping, overlay handling, submenu toggling, and body scroll locking

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68eb190c1ec8832c836219882a027041